### PR TITLE
Fix L2 native minting

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -5,6 +5,7 @@ out = "out"
 libs = ["lib"]
 fs_permissions = [
   { access = "read-write", path = "./deployments" },
+  { access = "read-write", path = "./out" },
 ]
 optimizer = true
 optimizer_runs = 10000

--- a/script/foundry/GlobalDeployerScript.s.sol
+++ b/script/foundry/GlobalDeployerScript.s.sol
@@ -10,22 +10,22 @@ import {Upgrader} from "./tasks/Upgrader.s.sol";
 import "./deploy/MgdDeployLibraries.s.sol";
 
 enum Action {
-    NOTHING,
-    DEPLOY,
-    UPGRADE,
-    CONFIGURE
+  NOTHING,
+  DEPLOY,
+  UPGRADE,
+  CONFIGURE
 }
 
 struct ContractActionConfiguration {
-    Action company;
-    Action memoir;
-    Action escrow;
-    Action mgd721;
-    Action mgd1155;
-    Action mgdVoucher721;
-    Action mgdVoucher1155;
-    Action mgdSetPrice;
-    Action mgdAuction;
+  Action company;
+  Action memoir;
+  Action escrow;
+  Action mgd721;
+  Action mgd1155;
+  Action mgdVoucher721;
+  Action mgdVoucher1155;
+  Action mgdSetPrice;
+  Action mgdAuction;
 }
 
 /**
@@ -34,430 +34,301 @@ struct ContractActionConfiguration {
  * --slow --verify --etherscan-api-key $<etherscan_key> --broadcast script/foundry/GlobalDeployerScript.s.sol
  */
 contract GlobalDeployerScript is FileSystem, MgdScriptConstants {
-    FileSystem fs;
+  FileSystem fs;
 
-    ContractActionConfiguration config =
-        ContractActionConfiguration({
-            company: Action.NOTHING,
-            memoir: Action.NOTHING,
-            escrow: Action.NOTHING,
-            mgd721: Action.NOTHING,
-            mgd1155: Action.NOTHING,
-            mgdVoucher721: Action.NOTHING,
-            mgdVoucher1155: Action.NOTHING,
-            mgdSetPrice: Action.NOTHING,
-            mgdAuction: Action.NOTHING
-        });
+  ContractActionConfiguration config = ContractActionConfiguration({
+    company: Action.NOTHING,
+    memoir: Action.NOTHING,
+    escrow: Action.NOTHING,
+    mgd721: Action.NOTHING,
+    mgd1155: Action.NOTHING,
+    mgdVoucher721: Action.NOTHING,
+    mgdVoucher1155: Action.NOTHING,
+    mgdSetPrice: Action.NOTHING,
+    mgdAuction: Action.NOTHING
+  });
 
-    function run() public {
-        fs = new FileSystem();
+  function run() public {
+    fs = new FileSystem();
 
-        // Set this to true if you want to deploy the marketplace with vouchers
-        // otherwise, it will deploy the marketplace with the standard NFTs
-        bool marketPlaceWithVouchers = false;
+    // Set this to true if you want to deploy the marketplace with vouchers
+    // otherwise, it will deploy the marketplace with the standard NFTs
+    bool marketPlaceWithVouchers = false;
 
-        vm.startBroadcast();
-        executeDeployActions(marketPlaceWithVouchers);
-        executeConfigureActions();
-        executeUpgradeActions();
-        vm.stopBroadcast();
+    vm.startBroadcast();
+    executeDeployActions(marketPlaceWithVouchers);
+    executeConfigureActions();
+    executeUpgradeActions();
+    vm.stopBroadcast();
+  }
+
+  function executeDeployActions(bool marketPlaceWithVouchers) internal {
+    string memory chainName = fs.getChainName(block.chainid);
+    string memory pairChain = fs.getPairChainName(block.chainid);
+
+    // MgdCompanyL2Sync
+    if (config.company == Action.DEPLOY) {
+      MgdCompanyL2SyncParams memory params = MgdCompanyL2SyncParams({
+        owner: msg.sender,
+        primarySaleFeePercent: _PRIMARY_SALE_FEE_PERCENT,
+        secondarySaleFeePercent: _SECONDARY_SALE_FEE_PERCENT,
+        collectorFee: _COLLECTOR_FEE,
+        maxRoyalty: _MAX_ROYALTY,
+        auctionDurationInMinutes: _AUCTION_DURATION,
+        auctionFinalMinute: _AUCTION_EXTENSION
+      });
+      MgdCompanyL2Sync company = MgdCompanyL2SyncDeployer.deployMgdCompanyL2Sync(fs, params, false);
+      company.setMessenger(getSafeAddress("Messenger", chainName));
     }
-
-    function executeDeployActions(bool marketPlaceWithVouchers) internal {
-        string memory chainName = fs.getChainName(block.chainid);
-        string memory pairChain = fs.getPairChainName(block.chainid);
-
-        // MgdCompanyL2Sync
-        if (config.company == Action.DEPLOY) {
-            MgdCompanyL2SyncParams memory params = MgdCompanyL2SyncParams({
-                owner: msg.sender,
-                primarySaleFeePercent: _PRIMARY_SALE_FEE_PERCENT,
-                secondarySaleFeePercent: _SECONDARY_SALE_FEE_PERCENT,
-                collectorFee: _COLLECTOR_FEE,
-                maxRoyalty: _MAX_ROYALTY,
-                auctionDurationInMinutes: _AUCTION_DURATION,
-                auctionFinalMinute: _AUCTION_EXTENSION
-            });
-            MgdCompanyL2Sync company = MgdCompanyL2SyncDeployer
-                .deployMgdCompanyL2Sync(fs, params, false);
-            company.setMessenger(getSafeAddress("Messenger", chainName));
-        }
-        // MintGoldDustMemoir
-        if (config.memoir == Action.DEPLOY) {
-            MintGoldDustMemoirDeployer.deployMintGoldDustMemoir(fs, false);
-        }
-        // MgdL2NFTEscrow
-        if (config.escrow == Action.DEPLOY) {
-            MgdL2NFTEscrowParams memory params = MgdL2NFTEscrowParams({
-                mgdCompanyL2Sync: getSafeAddress("MgdCompanyL2Sync", chainName)
-            });
-            MgdL2NFTEscrowDeployer.deployMgdL2NFTEscrow(fs, params, false);
-        }
-        // MgdERC721PermitEscrowable
-        if (config.mgd721 == Action.DEPLOY) {
-            MgdERC721PermitEscrowableParams
-                memory params = MgdERC721PermitEscrowableParams({
-                    mgdCompanyL2Sync: getSafeAddress(
-                        "MgdCompanyL2Sync",
-                        chainName
-                    )
-                });
-            MgdERC721PermitEscrowableDeployer.deployMgdERC721PermitEscrowable(
-                fs,
-                params,
-                false
-            );
-        }
-        // MgdERC1155PermitEscrowable
-        if (config.mgd1155 == Action.DEPLOY) {
-            MgdERC1155PermitEscrowableParams
-                memory params = MgdERC1155PermitEscrowableParams({
-                    mgdCompanyL2Sync: getSafeAddress(
-                        "MgdCompanyL2Sync",
-                        chainName
-                    ),
-                    baseURI: _BASE_URI
-                });
-            MgdERC1155PermitEscrowableDeployer.deployMgdERC1155PermitEscrowable(
-                    fs,
-                    params,
-                    false
-                );
-        }
-        // Mgd721L2Voucher
-        if (config.mgdVoucher721 == Action.DEPLOY) {
-            Mgd721L2VoucherParams memory params = Mgd721L2VoucherParams({
-                mgdCompanyL2Sync: getSafeAddress("MgdCompanyL2Sync", chainName),
-                mgdL2NFTescrow: getSafeAddress("MgdL2NFTEscrow", pairChain),
-                mgdERC721: getSafeAddress(
-                    "MgdERC721PermitEscrowable",
-                    pairChain
-                ),
-                crossDomainMessenger: getSafeAddress("Messenger", chainName)
-            });
-            Mgd721L2VoucherDeployer.deployMgd721L2Voucher(fs, params, false);
-        }
-        // Mgd1155L2Voucher
-        if (config.mgdVoucher1155 == Action.DEPLOY) {
-            Mgd1155L2VoucherParams memory params = Mgd1155L2VoucherParams({
-                mgdCompanyL2Sync: getSafeAddress("MgdCompanyL2Sync", chainName),
-                mgdL2NFTescrow: getSafeAddress("MgdL2NFTEscrow", pairChain),
-                mgdERC1155: getSafeAddress(
-                    "MgdERC1155PermitEscrowable",
-                    pairChain
-                ),
-                crossDomainMessenger: getSafeAddress("Messenger", chainName)
-            });
-            Mgd1155L2VoucherDeployer.deployMgd1155L2Voucher(fs, params, false);
-        }
-        // MintGoldDustSetPrice
-        if (config.mgdSetPrice == Action.DEPLOY) {
-            MintGoldDustSetPriceParams memory params;
-            params.mintGoldDustCompany = getSafeAddress(
-                "MgdCompanyL2Sync",
-                chainName
-            );
-            params.mintGoldDustERC721Address = payable(
-                getSafeAddress(
-                    marketPlaceWithVouchers
-                        ? "Mgd721L2Voucher"
-                        : "MgdERC721PermitEscrowable",
-                    chainName
-                )
-            );
-            params.mintGoldDustERC1155Address = payable(
-                getSafeAddress(
-                    marketPlaceWithVouchers
-                        ? "Mgd1155L2Voucher"
-                        : "MgdERC1155PermitEscrowable",
-                    chainName
-                )
-            );
-            MintGoldDustSetPriceDeployer.deployMintGoldDustSetPrice(
-                fs,
-                params,
-                false
-            );
-        }
-        // MintGoldDustMarketplaceAuction
-        if (config.mgdAuction == Action.DEPLOY) {
-            MintGoldDustMarketplaceAuctionParams memory params;
-            params.mintGoldDustCompany = getSafeAddress(
-                "MgdCompanyL2Sync",
-                chainName
-            );
-            params.mintGoldDustERC721Address = payable(
-                getSafeAddress(
-                    marketPlaceWithVouchers
-                        ? "Mgd721L2Voucher"
-                        : "MgdERC721PermitEscrowable",
-                    chainName
-                )
-            );
-            params.mintGoldDustERC1155Address = payable(
-                getSafeAddress(
-                    marketPlaceWithVouchers
-                        ? "Mgd1155L2Voucher"
-                        : "MgdERC1155PermitEscrowable",
-                    chainName
-                )
-            );
-            MintGoldDustMarketplaceAuctionDeployer
-                .deployMintGoldDustMarketplaceAuction(fs, params, false);
-        }
+    // MintGoldDustMemoir
+    if (config.memoir == Action.DEPLOY) {
+      MintGoldDustMemoirDeployer.deployMintGoldDustMemoir(fs, false);
     }
-
-    function executeConfigureActions() internal {
-        string memory chainName = fs.getChainName(block.chainid);
-        string memory pairChain = fs.getPairChainName(block.chainid);
-
-        // MgdCompanyL2Sync
-        if (config.company == Action.CONFIGURE) {
-            MgdCompanyL2Sync company = MgdCompanyL2Sync(
-                getSafeAddress("MgdCompanyL2Sync", chainName)
-            );
-            if (address(company.messenger()) == address(0)) {
-                company.setMessenger(getSafeAddress("Messenger", chainName));
-                console.log("Done! setting `messenger` in MgdCompanyL2Sync.");
-            }
-            company.setCrossDomainMGDCompany(
-                getPairChainId(block.chainid),
-                getSafeAddress("MgdCompanyL2Sync", pairChain)
-            );
-            console.log(
-                "Done! setting `crossDomainMGDCompany` in MgdCompanyL2Sync!"
-            );
-            company.setPublicKey(_MGD_SIGNER);
-            console.log("Done! setting `publicKey` in MgdCompanyL2Sync!");
-        }
-        // MgdL2NFTEscrow
-        if (config.escrow == Action.CONFIGURE) {
-            MgdL2NFTEscrow escrow = MgdL2NFTEscrow(
-                getSafeAddress("MgdL2NFTEscrow", chainName)
-            );
-            if (escrow.voucher721L2() == address(0)) {
-                escrow.setVoucherL2(
-                    getSafeAddress("Mgd721L2Voucher", chainName),
-                    TypeNFT.ERC721
-                );
-                console.log("Done! setting `voucher721L2` in MgdL2NFTEscrow!");
-            }
-
-            if (escrow.voucher1155L2() == address(0)) {
-                escrow.setVoucherL2(
-                    getSafeAddress("Mgd1155L2Voucher", chainName),
-                    TypeNFT.ERC1155
-                );
-                console.log("Done! setting `voucher1155L2` in MgdL2NFTEscrow!");
-            }
-        }
-        // MgdERC721PermitEscrowable
-        if (config.mgd721 == Action.CONFIGURE) {
-            MgdERC721PermitEscrowable mgd721 = MgdERC721PermitEscrowable(
-                getSafeAddress("MgdERC721PermitEscrowable", chainName)
-            );
-            mgd721.setMintGoldDustSetPriceAddress(
-                getSafeAddress("MintGoldDustSetPrice", chainName)
-            );
-            console.log("Done! setting `MintGoldDustSetPrice` in Mgd721!");
-            mgd721.setMintGoldDustMarketplaceAuctionAddress(
-                getSafeAddress("MintGoldDustMarketplaceAuction", chainName)
-            );
-            console.log(
-                "Done! setting `MintGoldDustMarketplaceAuction` in Mgd721!"
-            );
-
-            if (mgd721.escrow() == address(0)) {
-                mgd721.setEscrow(getSafeAddress("MgdL2NFTEscrow", pairChain));
-                console.log("Done! setting `escrow` in Mgd721!");
-            }
-        }
-        // MgdERC1155PermitEscrowable
-        if (config.mgd1155 == Action.CONFIGURE) {
-            MgdERC1155PermitEscrowable mgd1155 = MgdERC1155PermitEscrowable(
-                getSafeAddress("MgdERC1155PermitEscrowable", chainName)
-            );
-            mgd1155.setMintGoldDustSetPriceAddress(
-                getSafeAddress("MintGoldDustSetPrice", chainName)
-            );
-            console.log("Done! setting `MintGoldDustSetPrice` in Mgd1155!");
-            mgd1155.setMintGoldDustMarketplaceAuctionAddress(
-                getSafeAddress("MintGoldDustMarketplaceAuction", chainName)
-            );
-            console.log(
-                "Done! setting `MintGoldDustMarketplaceAuction` in Mgd1155!"
-            );
-            if (mgd1155.escrow() == address(0)) {
-                mgd1155.setEscrow(getSafeAddress("MgdL2NFTEscrow", pairChain));
-                console.log("Done! setting `escrow` in Mgd1155!");
-            }
-        }
-        // MintGoldDustSetPrice
-        if (config.mgdSetPrice == Action.CONFIGURE) {
-            MintGoldDustSetPrice setPrice = MintGoldDustSetPrice(
-                getSafeAddress("MintGoldDustSetPrice", chainName)
-            );
-            setPrice.setMintGoldDustMarketplace(
-                getSafeAddress("MintGoldDustMarketplaceAuction", chainName)
-            );
-            console.log(
-                "Done! setting `MintGoldDustMarketplace` in mgdSetPrice!"
-            );
-        }
-        // MintGoldDustMarketplaceAuction
-        if (config.mgdAuction == Action.CONFIGURE) {
-            MintGoldDustMarketplaceAuction auction = MintGoldDustMarketplaceAuction(
-                    getSafeAddress("MintGoldDustMarketplaceAuction", chainName)
-                );
-            auction.setMintGoldDustMarketplace(
-                getSafeAddress("MintGoldDustSetPrice", chainName)
-            );
-            console.log(
-                "Done! setting `MintGoldDustMarketplace` in mgdAuction!"
-            );
-        }
+    // MgdL2NFTEscrow
+    if (config.escrow == Action.DEPLOY) {
+      MgdL2NFTEscrowParams memory params =
+        MgdL2NFTEscrowParams({mgdCompanyL2Sync: getSafeAddress("MgdCompanyL2Sync", chainName)});
+      MgdL2NFTEscrowDeployer.deployMgdL2NFTEscrow(fs, params, false);
     }
-
-    function executeUpgradeActions() internal {
-        string memory chainName = fs.getChainName(block.chainid);
-
-        // MgdCompanyL2Sync
-        if (config.company == Action.UPGRADE) {
-            address companyProxy = getSafeAddress(
-                "MgdCompanyL2Sync",
-                chainName
-            );
-            MgdCompanyL2SyncParams memory emptyParams;
-            address newImpl = address(
-                MgdCompanyL2SyncDeployer.deployMgdCompanyL2Sync(
-                    fs,
-                    emptyParams,
-                    true
-                )
-            );
-            Upgrader.upgrade(fs, companyProxy, newImpl);
-        }
-        // MintGoldDustMemoir
-        if (config.memoir == Action.UPGRADE) {
-            address memoirProxy = getSafeAddress(
-                "MintGoldDustMemoir",
-                chainName
-            );
-            address newImpl = address(
-                MintGoldDustMemoirDeployer.deployMintGoldDustMemoir(fs, true)
-            );
-            Upgrader.upgrade(fs, memoirProxy, newImpl);
-        }
-        // MgdL2NFTEscrow
-        if (config.escrow == Action.UPGRADE) {
-            address escrowProxy = getSafeAddress("MgdL2NFTEscrow", chainName);
-            MgdL2NFTEscrowParams memory emptyParams;
-            address newImpl = address(
-                MgdL2NFTEscrowDeployer.deployMgdL2NFTEscrow(
-                    fs,
-                    emptyParams,
-                    true
-                )
-            );
-            Upgrader.upgrade(fs, escrowProxy, newImpl);
-        }
-        // MgdERC721PermitEscrowable
-        if (config.mgd721 == Action.UPGRADE) {
-            address mgd721Proxy = getSafeAddress(
-                "MgdERC721PermitEscrowable",
-                chainName
-            );
-            MgdERC721PermitEscrowableParams memory emptyParams;
-            address newImpl = address(
-                MgdERC721PermitEscrowableDeployer
-                    .deployMgdERC721PermitEscrowable(fs, emptyParams, true)
-            );
-            Upgrader.upgrade(fs, mgd721Proxy, newImpl);
-        }
-        // MgdERC1155PermitEscrowable
-        if (config.mgd1155 == Action.UPGRADE) {
-            address mgd1155Proxy = getSafeAddress(
-                "MgdERC1155PermitEscrowable",
-                chainName
-            );
-            MgdERC1155PermitEscrowableParams memory emptyParams;
-            address newImpl = address(
-                MgdERC1155PermitEscrowableDeployer
-                    .deployMgdERC1155PermitEscrowable(fs, emptyParams, true)
-            );
-            Upgrader.upgrade(fs, mgd1155Proxy, newImpl);
-        }
-        // Mgd721L2Voucher
-        if (config.mgdVoucher721 == Action.UPGRADE) {
-            address mgd721VoucherProxy = getSafeAddress(
-                "Mgd721L2Voucher",
-                chainName
-            );
-            Mgd721L2VoucherParams memory emptyParams;
-            address newImpl = address(
-                Mgd721L2VoucherDeployer.deployMgd721L2Voucher(
-                    fs,
-                    emptyParams,
-                    true
-                )
-            );
-            Upgrader.upgrade(fs, mgd721VoucherProxy, newImpl);
-        }
-        // Mgd1155L2Voucher
-        if (config.mgdVoucher1155 == Action.UPGRADE) {
-            address mgd1155VoucherProxy = getSafeAddress(
-                "Mgd1155L2Voucher",
-                chainName
-            );
-            Mgd1155L2VoucherParams memory emptyParams;
-            address newImpl = address(
-                Mgd1155L2VoucherDeployer.deployMgd1155L2Voucher(
-                    fs,
-                    emptyParams,
-                    true
-                )
-            );
-            Upgrader.upgrade(fs, mgd1155VoucherProxy, newImpl);
-        }
-        // MintGoldDustSetPrice
-        if (config.mgdSetPrice == Action.UPGRADE) {
-            address setPriceProxy = getSafeAddress(
-                "MintGoldDustSetPrice",
-                chainName
-            );
-            MintGoldDustSetPriceParams memory emptyParams;
-            address newImpl = address(
-                MintGoldDustSetPriceDeployer.deployMintGoldDustSetPrice(
-                    fs,
-                    emptyParams,
-                    true
-                )
-            );
-            Upgrader.upgrade(fs, setPriceProxy, newImpl);
-        }
-        // MintGoldDustMarketplaceAuction
-        if (config.mgdAuction == Action.UPGRADE) {
-            address auctionProxy = getSafeAddress(
-                "MintGoldDustMarketplaceAuction",
-                chainName
-            );
-            MintGoldDustMarketplaceAuctionParams memory emptyParams;
-            address newImpl = address(
-                MintGoldDustMarketplaceAuctionDeployer
-                    .deployMintGoldDustMarketplaceAuction(fs, emptyParams, true)
-            );
-            Upgrader.upgrade(fs, auctionProxy, newImpl);
-        }
+    // MgdERC721PermitEscrowable
+    if (config.mgd721 == Action.DEPLOY) {
+      MgdERC721PermitEscrowableParams memory params = MgdERC721PermitEscrowableParams({
+        mgdCompanyL2Sync: getSafeAddress("MgdCompanyL2Sync", chainName)
+      });
+      MgdERC721PermitEscrowableDeployer.deployMgdERC721PermitEscrowable(fs, params, false);
     }
-
-    function getSafeAddress(
-        string memory contractLabel,
-        string memory chainName
-    ) private returns (address) {
-        try fs.getAddress(contractLabel, chainName) returns (address addr) {
-            return addr;
-        } catch {
-            revert FileNotFound(chainName, contractLabel);
-        }
+    // MgdERC1155PermitEscrowable
+    if (config.mgd1155 == Action.DEPLOY) {
+      MgdERC1155PermitEscrowableParams memory params = MgdERC1155PermitEscrowableParams({
+        mgdCompanyL2Sync: getSafeAddress("MgdCompanyL2Sync", chainName),
+        baseURI: _BASE_URI
+      });
+      MgdERC1155PermitEscrowableDeployer.deployMgdERC1155PermitEscrowable(fs, params, false);
     }
+    // Mgd721L2Voucher
+    if (config.mgdVoucher721 == Action.DEPLOY) {
+      Mgd721L2VoucherParams memory params = Mgd721L2VoucherParams({
+        mgdCompanyL2Sync: getSafeAddress("MgdCompanyL2Sync", chainName),
+        mgdL2NFTescrow: getSafeAddress("MgdL2NFTEscrow", pairChain),
+        mgdERC721: getSafeAddress("MgdERC721PermitEscrowable", pairChain),
+        crossDomainMessenger: getSafeAddress("Messenger", chainName)
+      });
+      Mgd721L2VoucherDeployer.deployMgd721L2Voucher(fs, params, false);
+    }
+    // Mgd1155L2Voucher
+    if (config.mgdVoucher1155 == Action.DEPLOY) {
+      Mgd1155L2VoucherParams memory params = Mgd1155L2VoucherParams({
+        mgdCompanyL2Sync: getSafeAddress("MgdCompanyL2Sync", chainName),
+        mgdL2NFTescrow: getSafeAddress("MgdL2NFTEscrow", pairChain),
+        mgdERC1155: getSafeAddress("MgdERC1155PermitEscrowable", pairChain),
+        crossDomainMessenger: getSafeAddress("Messenger", chainName)
+      });
+      Mgd1155L2VoucherDeployer.deployMgd1155L2Voucher(fs, params, false);
+    }
+    // MintGoldDustSetPrice
+    if (config.mgdSetPrice == Action.DEPLOY) {
+      MintGoldDustSetPriceParams memory params;
+      params.mintGoldDustCompany = getSafeAddress("MgdCompanyL2Sync", chainName);
+      params.mintGoldDustERC721Address = payable(
+        getSafeAddress(
+          marketPlaceWithVouchers ? "Mgd721L2Voucher" : "MgdERC721PermitEscrowable", chainName
+        )
+      );
+      params.mintGoldDustERC1155Address = payable(
+        getSafeAddress(
+          marketPlaceWithVouchers ? "Mgd1155L2Voucher" : "MgdERC1155PermitEscrowable", chainName
+        )
+      );
+      MintGoldDustSetPriceDeployer.deployMintGoldDustSetPrice(fs, params, false);
+    }
+    // MintGoldDustMarketplaceAuction
+    if (config.mgdAuction == Action.DEPLOY) {
+      MintGoldDustMarketplaceAuctionParams memory params;
+      params.mintGoldDustCompany = getSafeAddress("MgdCompanyL2Sync", chainName);
+      params.mintGoldDustERC721Address = payable(
+        getSafeAddress(
+          marketPlaceWithVouchers ? "Mgd721L2Voucher" : "MgdERC721PermitEscrowable", chainName
+        )
+      );
+      params.mintGoldDustERC1155Address = payable(
+        getSafeAddress(
+          marketPlaceWithVouchers ? "Mgd1155L2Voucher" : "MgdERC1155PermitEscrowable", chainName
+        )
+      );
+      MintGoldDustMarketplaceAuctionDeployer.deployMintGoldDustMarketplaceAuction(fs, params, false);
+    }
+  }
+
+  function executeConfigureActions() internal {
+    string memory chainName = fs.getChainName(block.chainid);
+    string memory pairChain = fs.getPairChainName(block.chainid);
+
+    // MgdCompanyL2Sync
+    if (config.company == Action.CONFIGURE) {
+      MgdCompanyL2Sync company = MgdCompanyL2Sync(getSafeAddress("MgdCompanyL2Sync", chainName));
+      if (address(company.messenger()) == address(0)) {
+        company.setMessenger(getSafeAddress("Messenger", chainName));
+        console.log("Done! setting `messenger` in MgdCompanyL2Sync.");
+      }
+      company.setCrossDomainMGDCompany(
+        getPairChainId(block.chainid), getSafeAddress("MgdCompanyL2Sync", pairChain)
+      );
+      console.log("Done! setting `crossDomainMGDCompany` in MgdCompanyL2Sync!");
+      company.setPublicKey(_MGD_SIGNER);
+      console.log("Done! setting `publicKey` in MgdCompanyL2Sync!");
+    }
+    // MgdL2NFTEscrow
+    if (config.escrow == Action.CONFIGURE) {
+      MgdL2NFTEscrow escrow = MgdL2NFTEscrow(getSafeAddress("MgdL2NFTEscrow", chainName));
+      if (escrow.voucher721L2() == address(0)) {
+        escrow.setVoucherL2(getSafeAddress("Mgd721L2Voucher", chainName), TypeNFT.ERC721);
+        console.log("Done! setting `voucher721L2` in MgdL2NFTEscrow!");
+      }
+
+      if (escrow.voucher1155L2() == address(0)) {
+        escrow.setVoucherL2(getSafeAddress("Mgd1155L2Voucher", chainName), TypeNFT.ERC1155);
+        console.log("Done! setting `voucher1155L2` in MgdL2NFTEscrow!");
+      }
+    }
+    // MgdERC721PermitEscrowable
+    if (config.mgd721 == Action.CONFIGURE) {
+      MgdERC721PermitEscrowable mgd721 =
+        MgdERC721PermitEscrowable(getSafeAddress("MgdERC721PermitEscrowable", chainName));
+      mgd721.setMintGoldDustSetPriceAddress(getSafeAddress("MintGoldDustSetPrice", chainName));
+      console.log("Done! setting `MintGoldDustSetPrice` in Mgd721!");
+      mgd721.setMintGoldDustMarketplaceAuctionAddress(
+        getSafeAddress("MintGoldDustMarketplaceAuction", chainName)
+      );
+      console.log("Done! setting `MintGoldDustMarketplaceAuction` in Mgd721!");
+
+      if (mgd721.escrow() == address(0)) {
+        mgd721.setEscrow(getSafeAddress("MgdL2NFTEscrow", pairChain));
+        console.log("Done! setting `escrow` in Mgd721!");
+      }
+    }
+    // MgdERC1155PermitEscrowable
+    if (config.mgd1155 == Action.CONFIGURE) {
+      MgdERC1155PermitEscrowable mgd1155 =
+        MgdERC1155PermitEscrowable(getSafeAddress("MgdERC1155PermitEscrowable", chainName));
+      mgd1155.setMintGoldDustSetPriceAddress(getSafeAddress("MintGoldDustSetPrice", chainName));
+      console.log("Done! setting `MintGoldDustSetPrice` in Mgd1155!");
+      mgd1155.setMintGoldDustMarketplaceAuctionAddress(
+        getSafeAddress("MintGoldDustMarketplaceAuction", chainName)
+      );
+      console.log("Done! setting `MintGoldDustMarketplaceAuction` in Mgd1155!");
+      if (mgd1155.escrow() == address(0)) {
+        mgd1155.setEscrow(getSafeAddress("MgdL2NFTEscrow", pairChain));
+        console.log("Done! setting `escrow` in Mgd1155!");
+      }
+    }
+    // MintGoldDustSetPrice
+    if (config.mgdSetPrice == Action.CONFIGURE) {
+      MintGoldDustSetPrice setPrice =
+        MintGoldDustSetPrice(getSafeAddress("MintGoldDustSetPrice", chainName));
+      setPrice.setMintGoldDustMarketplace(
+        getSafeAddress("MintGoldDustMarketplaceAuction", chainName)
+      );
+      console.log("Done! setting `MintGoldDustMarketplace` in mgdSetPrice!");
+    }
+    // MintGoldDustMarketplaceAuction
+    if (config.mgdAuction == Action.CONFIGURE) {
+      MintGoldDustMarketplaceAuction auction =
+        MintGoldDustMarketplaceAuction(getSafeAddress("MintGoldDustMarketplaceAuction", chainName));
+      auction.setMintGoldDustMarketplace(getSafeAddress("MintGoldDustSetPrice", chainName));
+      console.log("Done! setting `MintGoldDustMarketplace` in mgdAuction!");
+    }
+  }
+
+  function executeUpgradeActions() internal {
+    string memory chainName = fs.getChainName(block.chainid);
+
+    // MgdCompanyL2Sync
+    if (config.company == Action.UPGRADE) {
+      address companyProxy = getSafeAddress("MgdCompanyL2Sync", chainName);
+      MgdCompanyL2SyncParams memory emptyParams;
+      address newImpl =
+        address(MgdCompanyL2SyncDeployer.deployMgdCompanyL2Sync(fs, emptyParams, true));
+      Upgrader.upgrade(fs, companyProxy, newImpl);
+    }
+    // MintGoldDustMemoir
+    if (config.memoir == Action.UPGRADE) {
+      address memoirProxy = getSafeAddress("MintGoldDustMemoir", chainName);
+      address newImpl = address(MintGoldDustMemoirDeployer.deployMintGoldDustMemoir(fs, true));
+      Upgrader.upgrade(fs, memoirProxy, newImpl);
+    }
+    // MgdL2NFTEscrow
+    if (config.escrow == Action.UPGRADE) {
+      address escrowProxy = getSafeAddress("MgdL2NFTEscrow", chainName);
+      MgdL2NFTEscrowParams memory emptyParams;
+      address newImpl = address(MgdL2NFTEscrowDeployer.deployMgdL2NFTEscrow(fs, emptyParams, true));
+      Upgrader.upgrade(fs, escrowProxy, newImpl);
+    }
+    // MgdERC721PermitEscrowable
+    if (config.mgd721 == Action.UPGRADE) {
+      address mgd721Proxy = getSafeAddress("MgdERC721PermitEscrowable", chainName);
+      MgdERC721PermitEscrowableParams memory emptyParams;
+      address newImpl = address(
+        MgdERC721PermitEscrowableDeployer.deployMgdERC721PermitEscrowable(fs, emptyParams, true)
+      );
+      Upgrader.upgrade(fs, mgd721Proxy, newImpl);
+    }
+    // MgdERC1155PermitEscrowable
+    if (config.mgd1155 == Action.UPGRADE) {
+      address mgd1155Proxy = getSafeAddress("MgdERC1155PermitEscrowable", chainName);
+      MgdERC1155PermitEscrowableParams memory emptyParams;
+      address newImpl = address(
+        MgdERC1155PermitEscrowableDeployer.deployMgdERC1155PermitEscrowable(fs, emptyParams, true)
+      );
+      Upgrader.upgrade(fs, mgd1155Proxy, newImpl);
+    }
+    // Mgd721L2Voucher
+    if (config.mgdVoucher721 == Action.UPGRADE) {
+      address mgd721VoucherProxy = getSafeAddress("Mgd721L2Voucher", chainName);
+      Mgd721L2VoucherParams memory emptyParams;
+      address newImpl =
+        address(Mgd721L2VoucherDeployer.deployMgd721L2Voucher(fs, emptyParams, true));
+      Upgrader.upgrade(fs, mgd721VoucherProxy, newImpl);
+    }
+    // Mgd1155L2Voucher
+    if (config.mgdVoucher1155 == Action.UPGRADE) {
+      address mgd1155VoucherProxy = getSafeAddress("Mgd1155L2Voucher", chainName);
+      Mgd1155L2VoucherParams memory emptyParams;
+      address newImpl =
+        address(Mgd1155L2VoucherDeployer.deployMgd1155L2Voucher(fs, emptyParams, true));
+      Upgrader.upgrade(fs, mgd1155VoucherProxy, newImpl);
+    }
+    // MintGoldDustSetPrice
+    if (config.mgdSetPrice == Action.UPGRADE) {
+      address setPriceProxy = getSafeAddress("MintGoldDustSetPrice", chainName);
+      MintGoldDustSetPriceParams memory emptyParams;
+      address newImpl =
+        address(MintGoldDustSetPriceDeployer.deployMintGoldDustSetPrice(fs, emptyParams, true));
+      Upgrader.upgrade(fs, setPriceProxy, newImpl);
+    }
+    // MintGoldDustMarketplaceAuction
+    if (config.mgdAuction == Action.UPGRADE) {
+      address auctionProxy = getSafeAddress("MintGoldDustMarketplaceAuction", chainName);
+      MintGoldDustMarketplaceAuctionParams memory emptyParams;
+      address newImpl = address(
+        MintGoldDustMarketplaceAuctionDeployer.deployMintGoldDustMarketplaceAuction(
+          fs, emptyParams, true
+        )
+      );
+      Upgrader.upgrade(fs, auctionProxy, newImpl);
+    }
+  }
+
+  function getSafeAddress(
+    string memory contractLabel,
+    string memory chainName
+  )
+    private
+    returns (address)
+  {
+    try fs.getAddress(contractLabel, chainName) returns (address addr) {
+      return addr;
+    } catch {
+      revert FileNotFound(chainName, contractLabel);
+    }
+  }
 }

--- a/script/foundry/MgdScriptConstants.s.sol
+++ b/script/foundry/MgdScriptConstants.s.sol
@@ -2,15 +2,14 @@
 pragma solidity 0.8.18;
 
 contract MgdScriptConstants {
-    uint256 internal constant _PRIMARY_SALE_FEE_PERCENT = 15e18;
-    uint256 internal constant _SECONDARY_SALE_FEE_PERCENT = 5e18;
-    uint256 internal constant _COLLECTOR_FEE = 3e18;
-    uint256 internal constant _MAX_ROYALTY = 20e18;
-    uint256 internal constant _AUCTION_DURATION = 1 days;
-    uint256 internal constant _AUCTION_EXTENSION = 5 minutes;
+  uint256 internal constant _PRIMARY_SALE_FEE_PERCENT = 15e18;
+  uint256 internal constant _SECONDARY_SALE_FEE_PERCENT = 5e18;
+  uint256 internal constant _COLLECTOR_FEE = 3e18;
+  uint256 internal constant _MAX_ROYALTY = 20e18;
+  uint256 internal constant _AUCTION_DURATION = 1 days;
+  uint256 internal constant _AUCTION_EXTENSION = 5 minutes;
 
-    string internal constant _BASE_URI = "https://www.mintgolddust.com/";
+  string internal constant _BASE_URI = "https://www.mintgolddust.com/";
 
-    address internal constant _MGD_SIGNER =
-        0x97d35f7dA031e3568d4528C04d5F498E3c3Dee70;
+  address internal constant _MGD_SIGNER = 0x97d35f7dA031e3568d4528C04d5F498E3c3Dee70;
 }

--- a/script/foundry/deploy/MgdDeployLibraries.s.sol
+++ b/script/foundry/deploy/MgdDeployLibraries.s.sol
@@ -1,12 +1,44 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.18;
 
-import {MgdCompanyL2SyncDeployer, MgdCompanyL2SyncParams, MgdCompanyL2Sync} from "./deploy_MgdCompanyL2Sync.s.sol";
+import {
+  MgdCompanyL2SyncDeployer,
+  MgdCompanyL2SyncParams,
+  MgdCompanyL2Sync
+} from "./deploy_MgdCompanyL2Sync.s.sol";
 import {MintGoldDustMemoirDeployer, MintGoldDustMemoir} from "./deploy_MintGoldDustMemoir.s.sol";
-import {MgdL2NFTEscrowDeployer, MgdL2NFTEscrowParams, MgdL2NFTEscrow} from "./deploy_MgdL2NFTEscrow.s.sol";
-import {MgdERC721PermitEscrowableDeployer, MgdERC721PermitEscrowableParams, MgdERC721PermitEscrowable} from "./deploy_MgdERC721PermitEscrowable.s.sol";
-import {MgdERC1155PermitEscrowableDeployer, MgdERC1155PermitEscrowableParams, MgdERC1155PermitEscrowable} from "./deploy_MgdERC1155PermitEscrowable.s.sol";
-import {Mgd721L2VoucherDeployer, Mgd721L2VoucherParams, Mgd721L2Voucher} from "./deploy_Mgd721L2Voucher.s.sol";
-import {Mgd1155L2VoucherDeployer, Mgd1155L2VoucherParams, Mgd1155L2Voucher} from "./deploy_Mgd1155L2Voucher.s.sol";
-import {MintGoldDustSetPriceDeployer, MintGoldDustSetPriceParams, MintGoldDustSetPrice} from "./deploy_MintGoldDustSetPrice.s.sol";
-import {MintGoldDustMarketplaceAuctionDeployer, MintGoldDustMarketplaceAuctionParams, MintGoldDustMarketplaceAuction} from "./deploy_MintGoldDustMarketplaceAuction.s.sol";
+import {
+  MgdL2NFTEscrowDeployer,
+  MgdL2NFTEscrowParams,
+  MgdL2NFTEscrow
+} from "./deploy_MgdL2NFTEscrow.s.sol";
+import {
+  MgdERC721PermitEscrowableDeployer,
+  MgdERC721PermitEscrowableParams,
+  MgdERC721PermitEscrowable
+} from "./deploy_MgdERC721PermitEscrowable.s.sol";
+import {
+  MgdERC1155PermitEscrowableDeployer,
+  MgdERC1155PermitEscrowableParams,
+  MgdERC1155PermitEscrowable
+} from "./deploy_MgdERC1155PermitEscrowable.s.sol";
+import {
+  Mgd721L2VoucherDeployer,
+  Mgd721L2VoucherParams,
+  Mgd721L2Voucher
+} from "./deploy_Mgd721L2Voucher.s.sol";
+import {
+  Mgd1155L2VoucherDeployer,
+  Mgd1155L2VoucherParams,
+  Mgd1155L2Voucher
+} from "./deploy_Mgd1155L2Voucher.s.sol";
+import {
+  MintGoldDustSetPriceDeployer,
+  MintGoldDustSetPriceParams,
+  MintGoldDustSetPrice
+} from "./deploy_MintGoldDustSetPrice.s.sol";
+import {
+  MintGoldDustMarketplaceAuctionDeployer,
+  MintGoldDustMarketplaceAuctionParams,
+  MintGoldDustMarketplaceAuction
+} from "./deploy_MintGoldDustMarketplaceAuction.s.sol";

--- a/script/foundry/deploy/deploy_Mgd1155L2Voucher.s.sol
+++ b/script/foundry/deploy/deploy_Mgd1155L2Voucher.s.sol
@@ -5,55 +5,56 @@ import {console} from "forge-std/console.sol";
 import {FileSystem} from "../utils/FileSystem.s.sol";
 import {Mgd1155L2Voucher} from "../../../src/voucher/Mgd1155L2Voucher.sol";
 import {ProxyAdmin, ProxyAdminDeployer} from "./deploy_ProxyAdmin.s.sol";
-import {TransparentUpgradeableProxy, TransparentProxyDeployer} from "./deploy_TransparentProxy.s.sol";
+import {
+  TransparentUpgradeableProxy, TransparentProxyDeployer
+} from "./deploy_TransparentProxy.s.sol";
 
 struct Mgd1155L2VoucherParams {
-    address mgdCompanyL2Sync;
-    address mgdL2NFTescrow;
-    address mgdERC1155;
-    address crossDomainMessenger;
+  address mgdCompanyL2Sync;
+  address mgdL2NFTescrow;
+  address mgdERC1155;
+  address crossDomainMessenger;
 }
 
 library Mgd1155L2VoucherDeployer {
-    function deployMgd1155L2Voucher(
-        FileSystem fs,
-        Mgd1155L2VoucherParams memory initParams,
-        bool onlyImplementation
-    ) internal returns (Mgd1155L2Voucher) {
-        string memory chainName = fs.getChainName(block.chainid);
-        console.log("Deploying Mgd1155L2Voucher...");
+  function deployMgd1155L2Voucher(
+    FileSystem fs,
+    Mgd1155L2VoucherParams memory initParams,
+    bool onlyImplementation
+  )
+    internal
+    returns (Mgd1155L2Voucher)
+  {
+    string memory chainName = fs.getChainName(block.chainid);
+    console.log("Deploying Mgd1155L2Voucher...");
 
-        Mgd1155L2Voucher instance = new Mgd1155L2Voucher();
+    Mgd1155L2Voucher instance = new Mgd1155L2Voucher();
 
-        console.log("Mgd1155L2Voucher implementation:", address(instance));
+    console.log("Mgd1155L2Voucher implementation:", address(instance));
 
-        if (onlyImplementation) {
-            return instance;
-        } else {
-            ProxyAdmin proxyAdmin;
-            try fs.getAddress("ProxyAdmin", chainName) returns (address addr) {
-                proxyAdmin = ProxyAdmin(addr);
-            } catch {
-                proxyAdmin = ProxyAdminDeployer.deployProxyAdmin(fs);
-            }
+    if (onlyImplementation) {
+      return instance;
+    } else {
+      ProxyAdmin proxyAdmin;
+      try fs.getAddress("ProxyAdmin", chainName) returns (address addr) {
+        proxyAdmin = ProxyAdmin(addr);
+      } catch {
+        proxyAdmin = ProxyAdminDeployer.deployProxyAdmin(fs);
+      }
 
-            bytes memory initData = abi.encodeWithSelector(
-                Mgd1155L2Voucher.initialize.selector,
-                initParams.mgdCompanyL2Sync,
-                initParams.mgdL2NFTescrow,
-                initParams.mgdERC1155,
-                initParams.crossDomainMessenger
-            );
+      bytes memory initData = abi.encodeWithSelector(
+        Mgd1155L2Voucher.initialize.selector,
+        initParams.mgdCompanyL2Sync,
+        initParams.mgdL2NFTescrow,
+        initParams.mgdERC1155,
+        initParams.crossDomainMessenger
+      );
 
-            address proxy = TransparentProxyDeployer.deployTransparentProxy(
-                fs,
-                address(proxyAdmin),
-                address(instance),
-                initData,
-                "Mgd1155L2Voucher"
-            );
-            console.log("Saved Mgd1155L2Voucher filesystem:", proxy);
-            return Mgd1155L2Voucher(proxy);
-        }
+      address proxy = TransparentProxyDeployer.deployTransparentProxy(
+        fs, address(proxyAdmin), address(instance), initData, "Mgd1155L2Voucher"
+      );
+      console.log("Saved Mgd1155L2Voucher filesystem:", proxy);
+      return Mgd1155L2Voucher(proxy);
     }
+  }
 }

--- a/script/foundry/deploy/deploy_Mgd721L2Voucher.s.sol
+++ b/script/foundry/deploy/deploy_Mgd721L2Voucher.s.sol
@@ -5,55 +5,56 @@ import {console} from "forge-std/console.sol";
 import {FileSystem} from "../utils/FileSystem.s.sol";
 import {Mgd721L2Voucher} from "../../../src/voucher/Mgd721L2Voucher.sol";
 import {ProxyAdmin, ProxyAdminDeployer} from "./deploy_ProxyAdmin.s.sol";
-import {TransparentUpgradeableProxy, TransparentProxyDeployer} from "./deploy_TransparentProxy.s.sol";
+import {
+  TransparentUpgradeableProxy, TransparentProxyDeployer
+} from "./deploy_TransparentProxy.s.sol";
 
 struct Mgd721L2VoucherParams {
-    address mgdCompanyL2Sync;
-    address mgdL2NFTescrow;
-    address mgdERC721;
-    address crossDomainMessenger;
+  address mgdCompanyL2Sync;
+  address mgdL2NFTescrow;
+  address mgdERC721;
+  address crossDomainMessenger;
 }
 
 library Mgd721L2VoucherDeployer {
-    function deployMgd721L2Voucher(
-        FileSystem fs,
-        Mgd721L2VoucherParams memory initParams,
-        bool onlyImplementation
-    ) internal returns (Mgd721L2Voucher) {
-        string memory chainName = fs.getChainName(block.chainid);
-        console.log("Deploying Mgd721L2Voucher...");
+  function deployMgd721L2Voucher(
+    FileSystem fs,
+    Mgd721L2VoucherParams memory initParams,
+    bool onlyImplementation
+  )
+    internal
+    returns (Mgd721L2Voucher)
+  {
+    string memory chainName = fs.getChainName(block.chainid);
+    console.log("Deploying Mgd721L2Voucher...");
 
-        Mgd721L2Voucher instance = new Mgd721L2Voucher();
+    Mgd721L2Voucher instance = new Mgd721L2Voucher();
 
-        console.log("Mgd721L2Voucher implementation:", address(instance));
+    console.log("Mgd721L2Voucher implementation:", address(instance));
 
-        if (onlyImplementation) {
-            return instance;
-        } else {
-            ProxyAdmin proxyAdmin;
-            try fs.getAddress("ProxyAdmin", chainName) returns (address addr) {
-                proxyAdmin = ProxyAdmin(addr);
-            } catch {
-                proxyAdmin = ProxyAdminDeployer.deployProxyAdmin(fs);
-            }
+    if (onlyImplementation) {
+      return instance;
+    } else {
+      ProxyAdmin proxyAdmin;
+      try fs.getAddress("ProxyAdmin", chainName) returns (address addr) {
+        proxyAdmin = ProxyAdmin(addr);
+      } catch {
+        proxyAdmin = ProxyAdminDeployer.deployProxyAdmin(fs);
+      }
 
-            bytes memory initData = abi.encodeWithSelector(
-                Mgd721L2Voucher.initialize.selector,
-                initParams.mgdCompanyL2Sync,
-                initParams.mgdL2NFTescrow,
-                initParams.mgdERC721,
-                initParams.crossDomainMessenger
-            );
+      bytes memory initData = abi.encodeWithSelector(
+        Mgd721L2Voucher.initialize.selector,
+        initParams.mgdCompanyL2Sync,
+        initParams.mgdL2NFTescrow,
+        initParams.mgdERC721,
+        initParams.crossDomainMessenger
+      );
 
-            address proxy = TransparentProxyDeployer.deployTransparentProxy(
-                fs,
-                address(proxyAdmin),
-                address(instance),
-                initData,
-                "Mgd721L2Voucher"
-            );
-            console.log("Saved Mgd721L2Voucher filesystem:", proxy);
-            return Mgd721L2Voucher(proxy);
-        }
+      address proxy = TransparentProxyDeployer.deployTransparentProxy(
+        fs, address(proxyAdmin), address(instance), initData, "Mgd721L2Voucher"
+      );
+      console.log("Saved Mgd721L2Voucher filesystem:", proxy);
+      return Mgd721L2Voucher(proxy);
     }
+  }
 }

--- a/script/foundry/deploy/deploy_MgdCompanyL2Sync.s.sol
+++ b/script/foundry/deploy/deploy_MgdCompanyL2Sync.s.sol
@@ -5,61 +5,62 @@ import {console} from "forge-std/console.sol";
 import {FileSystem} from "../utils/FileSystem.s.sol";
 import {MgdCompanyL2Sync, MintGoldDustCompany} from "../../../src/MgdCompanyL2Sync.sol";
 import {ProxyAdmin, ProxyAdminDeployer} from "./deploy_ProxyAdmin.s.sol";
-import {TransparentUpgradeableProxy, TransparentProxyDeployer} from "./deploy_TransparentProxy.s.sol";
+import {
+  TransparentUpgradeableProxy, TransparentProxyDeployer
+} from "./deploy_TransparentProxy.s.sol";
 
 struct MgdCompanyL2SyncParams {
-    address owner;
-    uint256 primarySaleFeePercent;
-    uint256 secondarySaleFeePercent;
-    uint256 collectorFee;
-    uint256 maxRoyalty;
-    uint256 auctionDurationInMinutes;
-    uint256 auctionFinalMinute;
+  address owner;
+  uint256 primarySaleFeePercent;
+  uint256 secondarySaleFeePercent;
+  uint256 collectorFee;
+  uint256 maxRoyalty;
+  uint256 auctionDurationInMinutes;
+  uint256 auctionFinalMinute;
 }
 
 library MgdCompanyL2SyncDeployer {
-    function deployMgdCompanyL2Sync(
-        FileSystem fs,
-        MgdCompanyL2SyncParams memory initParams,
-        bool onlyImplementation
-    ) internal returns (MgdCompanyL2Sync) {
-        string memory chainName = fs.getChainName(block.chainid);
-        console.log("Deploying MgdCompanyL2Sync...");
+  function deployMgdCompanyL2Sync(
+    FileSystem fs,
+    MgdCompanyL2SyncParams memory initParams,
+    bool onlyImplementation
+  )
+    internal
+    returns (MgdCompanyL2Sync)
+  {
+    string memory chainName = fs.getChainName(block.chainid);
+    console.log("Deploying MgdCompanyL2Sync...");
 
-        MgdCompanyL2Sync instance = new MgdCompanyL2Sync();
+    MgdCompanyL2Sync instance = new MgdCompanyL2Sync();
 
-        console.log("MgdCompanyL2Sync implementation:", address(instance));
+    console.log("MgdCompanyL2Sync implementation:", address(instance));
 
-        if (onlyImplementation) {
-            return instance;
-        } else {
-            ProxyAdmin proxyAdmin;
-            try fs.getAddress("ProxyAdmin", chainName) returns (address addr) {
-                proxyAdmin = ProxyAdmin(addr);
-            } catch {
-                proxyAdmin = ProxyAdminDeployer.deployProxyAdmin(fs);
-            }
+    if (onlyImplementation) {
+      return instance;
+    } else {
+      ProxyAdmin proxyAdmin;
+      try fs.getAddress("ProxyAdmin", chainName) returns (address addr) {
+        proxyAdmin = ProxyAdmin(addr);
+      } catch {
+        proxyAdmin = ProxyAdminDeployer.deployProxyAdmin(fs);
+      }
 
-            bytes memory initData = abi.encodeWithSelector(
-                MintGoldDustCompany.initialize.selector,
-                initParams.owner,
-                initParams.primarySaleFeePercent,
-                initParams.secondarySaleFeePercent,
-                initParams.collectorFee,
-                initParams.maxRoyalty,
-                initParams.auctionDurationInMinutes,
-                initParams.auctionFinalMinute
-            );
+      bytes memory initData = abi.encodeWithSelector(
+        MintGoldDustCompany.initialize.selector,
+        initParams.owner,
+        initParams.primarySaleFeePercent,
+        initParams.secondarySaleFeePercent,
+        initParams.collectorFee,
+        initParams.maxRoyalty,
+        initParams.auctionDurationInMinutes,
+        initParams.auctionFinalMinute
+      );
 
-            address proxy = TransparentProxyDeployer.deployTransparentProxy(
-                fs,
-                address(proxyAdmin),
-                address(instance),
-                initData,
-                "MgdCompanyL2Sync"
-            );
-            console.log("Saved MgdCompanyL2Sync filesystem:", proxy);
-            return MgdCompanyL2Sync(proxy);
-        }
+      address proxy = TransparentProxyDeployer.deployTransparentProxy(
+        fs, address(proxyAdmin), address(instance), initData, "MgdCompanyL2Sync"
+      );
+      console.log("Saved MgdCompanyL2Sync filesystem:", proxy);
+      return MgdCompanyL2Sync(proxy);
     }
+  }
 }

--- a/script/foundry/deploy/deploy_MgdERC1155PermitEscrowable.s.sol
+++ b/script/foundry/deploy/deploy_MgdERC1155PermitEscrowable.s.sol
@@ -3,56 +3,57 @@ pragma solidity 0.8.18;
 
 import {console} from "forge-std/console.sol";
 import {FileSystem} from "../utils/FileSystem.s.sol";
-import {MgdERC1155PermitEscrowable, MintGoldDustERC1155} from "../../../src/MgdERC1155PermitEscrowable.sol";
+import {
+  MgdERC1155PermitEscrowable,
+  MintGoldDustERC1155
+} from "../../../src/MgdERC1155PermitEscrowable.sol";
 import {ProxyAdmin, ProxyAdminDeployer} from "./deploy_ProxyAdmin.s.sol";
-import {TransparentUpgradeableProxy, TransparentProxyDeployer} from "./deploy_TransparentProxy.s.sol";
+import {
+  TransparentUpgradeableProxy, TransparentProxyDeployer
+} from "./deploy_TransparentProxy.s.sol";
 
 struct MgdERC1155PermitEscrowableParams {
-    address mgdCompanyL2Sync;
-    string baseURI;
+  address mgdCompanyL2Sync;
+  string baseURI;
 }
 
 library MgdERC1155PermitEscrowableDeployer {
-    function deployMgdERC1155PermitEscrowable(
-        FileSystem fs,
-        MgdERC1155PermitEscrowableParams memory initParams,
-        bool onlyImplementation
-    ) internal returns (MgdERC1155PermitEscrowable) {
-        string memory chainName = fs.getChainName(block.chainid);
-        console.log("Deploying MgdERC1155PermitEscrowable...");
+  function deployMgdERC1155PermitEscrowable(
+    FileSystem fs,
+    MgdERC1155PermitEscrowableParams memory initParams,
+    bool onlyImplementation
+  )
+    internal
+    returns (MgdERC1155PermitEscrowable)
+  {
+    string memory chainName = fs.getChainName(block.chainid);
+    console.log("Deploying MgdERC1155PermitEscrowable...");
 
-        MgdERC1155PermitEscrowable instance = new MgdERC1155PermitEscrowable();
+    MgdERC1155PermitEscrowable instance = new MgdERC1155PermitEscrowable();
 
-        console.log(
-            "MgdERC1155PermitEscrowable implementation:",
-            address(instance)
-        );
+    console.log("MgdERC1155PermitEscrowable implementation:", address(instance));
 
-        if (onlyImplementation) {
-            return instance;
-        } else {
-            ProxyAdmin proxyAdmin;
-            try fs.getAddress("ProxyAdmin", chainName) returns (address addr) {
-                proxyAdmin = ProxyAdmin(addr);
-            } catch {
-                proxyAdmin = ProxyAdminDeployer.deployProxyAdmin(fs);
-            }
+    if (onlyImplementation) {
+      return instance;
+    } else {
+      ProxyAdmin proxyAdmin;
+      try fs.getAddress("ProxyAdmin", chainName) returns (address addr) {
+        proxyAdmin = ProxyAdmin(addr);
+      } catch {
+        proxyAdmin = ProxyAdminDeployer.deployProxyAdmin(fs);
+      }
 
-            bytes memory initData = abi.encodeWithSelector(
-                MintGoldDustERC1155.initializeChild.selector,
-                initParams.mgdCompanyL2Sync,
-                initParams.baseURI
-            );
+      bytes memory initData = abi.encodeWithSelector(
+        MintGoldDustERC1155.initializeChild.selector,
+        initParams.mgdCompanyL2Sync,
+        initParams.baseURI
+      );
 
-            address proxy = TransparentProxyDeployer.deployTransparentProxy(
-                fs,
-                address(proxyAdmin),
-                address(instance),
-                initData,
-                "MgdERC1155PermitEscrowable"
-            );
-            console.log("Saved MgdERC1155PermitEscrowable filesystem:", proxy);
-            return MgdERC1155PermitEscrowable(proxy);
-        }
+      address proxy = TransparentProxyDeployer.deployTransparentProxy(
+        fs, address(proxyAdmin), address(instance), initData, "MgdERC1155PermitEscrowable"
+      );
+      console.log("Saved MgdERC1155PermitEscrowable filesystem:", proxy);
+      return MgdERC1155PermitEscrowable(proxy);
     }
+  }
 }

--- a/script/foundry/deploy/deploy_MgdERC721PermitEscrowable.s.sol
+++ b/script/foundry/deploy/deploy_MgdERC721PermitEscrowable.s.sol
@@ -3,54 +3,53 @@ pragma solidity 0.8.18;
 
 import {console} from "forge-std/console.sol";
 import {FileSystem} from "../utils/FileSystem.s.sol";
-import {MgdERC721PermitEscrowable, MintGoldDustERC721} from "../../../src/MgdERC721PermitEscrowable.sol";
+import {
+  MgdERC721PermitEscrowable, MintGoldDustERC721
+} from "../../../src/MgdERC721PermitEscrowable.sol";
 import {ProxyAdmin, ProxyAdminDeployer} from "./deploy_ProxyAdmin.s.sol";
-import {TransparentUpgradeableProxy, TransparentProxyDeployer} from "./deploy_TransparentProxy.s.sol";
+import {
+  TransparentUpgradeableProxy, TransparentProxyDeployer
+} from "./deploy_TransparentProxy.s.sol";
 
 struct MgdERC721PermitEscrowableParams {
-    address mgdCompanyL2Sync;
+  address mgdCompanyL2Sync;
 }
 
 library MgdERC721PermitEscrowableDeployer {
-    function deployMgdERC721PermitEscrowable(
-        FileSystem fs,
-        MgdERC721PermitEscrowableParams memory initParams,
-        bool onlyImplementation
-    ) internal returns (MgdERC721PermitEscrowable) {
-        string memory chainName = fs.getChainName(block.chainid);
-        console.log("Deploying MgdERC721PermitEscrowable...");
+  function deployMgdERC721PermitEscrowable(
+    FileSystem fs,
+    MgdERC721PermitEscrowableParams memory initParams,
+    bool onlyImplementation
+  )
+    internal
+    returns (MgdERC721PermitEscrowable)
+  {
+    string memory chainName = fs.getChainName(block.chainid);
+    console.log("Deploying MgdERC721PermitEscrowable...");
 
-        MgdERC721PermitEscrowable instance = new MgdERC721PermitEscrowable();
+    MgdERC721PermitEscrowable instance = new MgdERC721PermitEscrowable();
 
-        console.log(
-            "MgdERC721PermitEscrowable implementation:",
-            address(instance)
-        );
+    console.log("MgdERC721PermitEscrowable implementation:", address(instance));
 
-        if (onlyImplementation) {
-            return instance;
-        } else {
-            ProxyAdmin proxyAdmin;
-            try fs.getAddress("ProxyAdmin", chainName) returns (address addr) {
-                proxyAdmin = ProxyAdmin(addr);
-            } catch {
-                proxyAdmin = ProxyAdminDeployer.deployProxyAdmin(fs);
-            }
+    if (onlyImplementation) {
+      return instance;
+    } else {
+      ProxyAdmin proxyAdmin;
+      try fs.getAddress("ProxyAdmin", chainName) returns (address addr) {
+        proxyAdmin = ProxyAdmin(addr);
+      } catch {
+        proxyAdmin = ProxyAdminDeployer.deployProxyAdmin(fs);
+      }
 
-            bytes memory initData = abi.encodeWithSelector(
-                MintGoldDustERC721.initializeChild.selector,
-                initParams.mgdCompanyL2Sync
-            );
+      bytes memory initData = abi.encodeWithSelector(
+        MintGoldDustERC721.initializeChild.selector, initParams.mgdCompanyL2Sync
+      );
 
-            address proxy = TransparentProxyDeployer.deployTransparentProxy(
-                fs,
-                address(proxyAdmin),
-                address(instance),
-                initData,
-                "MgdERC721PermitEscrowable"
-            );
-            console.log("Saved MgdERC721PermitEscrowable filesystem:", proxy);
-            return MgdERC721PermitEscrowable(proxy);
-        }
+      address proxy = TransparentProxyDeployer.deployTransparentProxy(
+        fs, address(proxyAdmin), address(instance), initData, "MgdERC721PermitEscrowable"
+      );
+      console.log("Saved MgdERC721PermitEscrowable filesystem:", proxy);
+      return MgdERC721PermitEscrowable(proxy);
     }
+  }
 }

--- a/script/foundry/deploy/deploy_MgdL2NFTEscrow.s.sol
+++ b/script/foundry/deploy/deploy_MgdL2NFTEscrow.s.sol
@@ -5,49 +5,48 @@ import {console} from "forge-std/console.sol";
 import {FileSystem} from "../utils/FileSystem.s.sol";
 import {MgdL2NFTEscrow} from "../../../src/MgdL2NFTEscrow.sol";
 import {ProxyAdmin, ProxyAdminDeployer} from "./deploy_ProxyAdmin.s.sol";
-import {TransparentUpgradeableProxy, TransparentProxyDeployer} from "./deploy_TransparentProxy.s.sol";
+import {
+  TransparentUpgradeableProxy, TransparentProxyDeployer
+} from "./deploy_TransparentProxy.s.sol";
 
 struct MgdL2NFTEscrowParams {
-    address mgdCompanyL2Sync;
+  address mgdCompanyL2Sync;
 }
 
 library MgdL2NFTEscrowDeployer {
-    function deployMgdL2NFTEscrow(
-        FileSystem fs,
-        MgdL2NFTEscrowParams memory initParams,
-        bool onlyImplementation
-    ) internal returns (MgdL2NFTEscrow) {
-        string memory chainName = fs.getChainName(block.chainid);
-        console.log("Deploying MgdL2NFTEscrow...");
+  function deployMgdL2NFTEscrow(
+    FileSystem fs,
+    MgdL2NFTEscrowParams memory initParams,
+    bool onlyImplementation
+  )
+    internal
+    returns (MgdL2NFTEscrow)
+  {
+    string memory chainName = fs.getChainName(block.chainid);
+    console.log("Deploying MgdL2NFTEscrow...");
 
-        MgdL2NFTEscrow instance = new MgdL2NFTEscrow();
+    MgdL2NFTEscrow instance = new MgdL2NFTEscrow();
 
-        console.log("MgdL2NFTEscrow implementation:", address(instance));
+    console.log("MgdL2NFTEscrow implementation:", address(instance));
 
-        if (onlyImplementation) {
-            return instance;
-        } else {
-            ProxyAdmin proxyAdmin;
-            try fs.getAddress("ProxyAdmin", chainName) returns (address addr) {
-                proxyAdmin = ProxyAdmin(addr);
-            } catch {
-                proxyAdmin = ProxyAdminDeployer.deployProxyAdmin(fs);
-            }
+    if (onlyImplementation) {
+      return instance;
+    } else {
+      ProxyAdmin proxyAdmin;
+      try fs.getAddress("ProxyAdmin", chainName) returns (address addr) {
+        proxyAdmin = ProxyAdmin(addr);
+      } catch {
+        proxyAdmin = ProxyAdminDeployer.deployProxyAdmin(fs);
+      }
 
-            bytes memory initData = abi.encodeWithSelector(
-                MgdL2NFTEscrow.initialize.selector,
-                initParams.mgdCompanyL2Sync
-            );
+      bytes memory initData =
+        abi.encodeWithSelector(MgdL2NFTEscrow.initialize.selector, initParams.mgdCompanyL2Sync);
 
-            address proxy = TransparentProxyDeployer.deployTransparentProxy(
-                fs,
-                address(proxyAdmin),
-                address(instance),
-                initData,
-                "MgdL2NFTEscrow"
-            );
-            console.log("Saved MgdL2NFTEscrow filesystem:", proxy);
-            return MgdL2NFTEscrow(proxy);
-        }
+      address proxy = TransparentProxyDeployer.deployTransparentProxy(
+        fs, address(proxyAdmin), address(instance), initData, "MgdL2NFTEscrow"
+      );
+      console.log("Saved MgdL2NFTEscrow filesystem:", proxy);
+      return MgdL2NFTEscrow(proxy);
     }
+  }
 }

--- a/script/foundry/deploy/deploy_MintGoldDustMarketplaceAuction.s.sol
+++ b/script/foundry/deploy/deploy_MintGoldDustMarketplaceAuction.s.sol
@@ -3,61 +3,57 @@ pragma solidity 0.8.18;
 
 import {console} from "forge-std/console.sol";
 import {FileSystem} from "../utils/FileSystem.s.sol";
-import {MintGoldDustMarketplaceAuction} from "mgd-v2-contracts/marketplace/MintGoldDustMarketplaceAuction.sol";
+import {MintGoldDustMarketplaceAuction} from
+  "mgd-v2-contracts/marketplace/MintGoldDustMarketplaceAuction.sol";
 import {ProxyAdmin, ProxyAdminDeployer} from "./deploy_ProxyAdmin.s.sol";
-import {TransparentUpgradeableProxy, TransparentProxyDeployer} from "./deploy_TransparentProxy.s.sol";
+import {
+  TransparentUpgradeableProxy, TransparentProxyDeployer
+} from "./deploy_TransparentProxy.s.sol";
 
 struct MintGoldDustMarketplaceAuctionParams {
-    address mintGoldDustCompany;
-    address payable mintGoldDustERC721Address;
-    address payable mintGoldDustERC1155Address;
+  address mintGoldDustCompany;
+  address payable mintGoldDustERC721Address;
+  address payable mintGoldDustERC1155Address;
 }
 
 library MintGoldDustMarketplaceAuctionDeployer {
-    function deployMintGoldDustMarketplaceAuction(
-        FileSystem fs,
-        MintGoldDustMarketplaceAuctionParams memory initParams,
-        bool onlyImplementation
-    ) internal returns (MintGoldDustMarketplaceAuction) {
-        string memory chainName = fs.getChainName(block.chainid);
-        console.log("Deploying MintGoldDustMarketplaceAuction...");
+  function deployMintGoldDustMarketplaceAuction(
+    FileSystem fs,
+    MintGoldDustMarketplaceAuctionParams memory initParams,
+    bool onlyImplementation
+  )
+    internal
+    returns (MintGoldDustMarketplaceAuction)
+  {
+    string memory chainName = fs.getChainName(block.chainid);
+    console.log("Deploying MintGoldDustMarketplaceAuction...");
 
-        MintGoldDustMarketplaceAuction instance = new MintGoldDustMarketplaceAuction();
+    MintGoldDustMarketplaceAuction instance = new MintGoldDustMarketplaceAuction();
 
-        console.log(
-            "MintGoldDustMarketplaceAuction implementation:",
-            address(instance)
-        );
+    console.log("MintGoldDustMarketplaceAuction implementation:", address(instance));
 
-        if (onlyImplementation) {
-            return instance;
-        } else {
-            ProxyAdmin proxyAdmin;
-            try fs.getAddress("ProxyAdmin", chainName) returns (address addr) {
-                proxyAdmin = ProxyAdmin(addr);
-            } catch {
-                proxyAdmin = ProxyAdminDeployer.deployProxyAdmin(fs);
-            }
+    if (onlyImplementation) {
+      return instance;
+    } else {
+      ProxyAdmin proxyAdmin;
+      try fs.getAddress("ProxyAdmin", chainName) returns (address addr) {
+        proxyAdmin = ProxyAdmin(addr);
+      } catch {
+        proxyAdmin = ProxyAdminDeployer.deployProxyAdmin(fs);
+      }
 
-            bytes memory initData = abi.encodeWithSelector(
-                MintGoldDustMarketplaceAuction.initializeChild.selector,
-                initParams.mintGoldDustCompany,
-                initParams.mintGoldDustERC721Address,
-                initParams.mintGoldDustERC1155Address
-            );
+      bytes memory initData = abi.encodeWithSelector(
+        MintGoldDustMarketplaceAuction.initializeChild.selector,
+        initParams.mintGoldDustCompany,
+        initParams.mintGoldDustERC721Address,
+        initParams.mintGoldDustERC1155Address
+      );
 
-            address proxy = TransparentProxyDeployer.deployTransparentProxy(
-                fs,
-                address(proxyAdmin),
-                address(instance),
-                initData,
-                "MintGoldDustMarketplaceAuction"
-            );
-            console.log(
-                "Saved MintGoldDustMarketplaceAuction filesystem:",
-                proxy
-            );
-            return MintGoldDustMarketplaceAuction(proxy);
-        }
+      address proxy = TransparentProxyDeployer.deployTransparentProxy(
+        fs, address(proxyAdmin), address(instance), initData, "MintGoldDustMarketplaceAuction"
+      );
+      console.log("Saved MintGoldDustMarketplaceAuction filesystem:", proxy);
+      return MintGoldDustMarketplaceAuction(proxy);
     }
+  }
 }

--- a/script/foundry/deploy/deploy_MintGoldDustMemoir.s.sol
+++ b/script/foundry/deploy/deploy_MintGoldDustMemoir.s.sol
@@ -5,40 +5,41 @@ import {console} from "forge-std/console.sol";
 import {FileSystem} from "../utils/FileSystem.s.sol";
 import {MintGoldDustMemoir} from "mgd-v2-contracts/marketplace/MintGoldDustMemoir.sol";
 import {ProxyAdmin, ProxyAdminDeployer} from "./deploy_ProxyAdmin.s.sol";
-import {TransparentUpgradeableProxy, TransparentProxyDeployer} from "./deploy_TransparentProxy.s.sol";
+import {
+  TransparentUpgradeableProxy, TransparentProxyDeployer
+} from "./deploy_TransparentProxy.s.sol";
 
 library MintGoldDustMemoirDeployer {
-    function deployMintGoldDustMemoir(
-        FileSystem fs,
-        bool onlyImplementation
-    ) internal returns (MintGoldDustMemoir) {
-        string memory chainName = fs.getChainName(block.chainid);
-        console.log("Deploying MintGoldDustMemoir...");
+  function deployMintGoldDustMemoir(
+    FileSystem fs,
+    bool onlyImplementation
+  )
+    internal
+    returns (MintGoldDustMemoir)
+  {
+    string memory chainName = fs.getChainName(block.chainid);
+    console.log("Deploying MintGoldDustMemoir...");
 
-        MintGoldDustMemoir instance = new MintGoldDustMemoir();
+    MintGoldDustMemoir instance = new MintGoldDustMemoir();
 
-        console.log("MintGoldDustMemoir implementation:", address(instance));
+    console.log("MintGoldDustMemoir implementation:", address(instance));
 
-        if (onlyImplementation) {
-            return instance;
-        } else {
-            ProxyAdmin proxyAdmin;
-            try fs.getAddress("ProxyAdmin", chainName) returns (address addr) {
-                proxyAdmin = ProxyAdmin(addr);
-            } catch {
-                proxyAdmin = ProxyAdminDeployer.deployProxyAdmin(fs);
-            }
+    if (onlyImplementation) {
+      return instance;
+    } else {
+      ProxyAdmin proxyAdmin;
+      try fs.getAddress("ProxyAdmin", chainName) returns (address addr) {
+        proxyAdmin = ProxyAdmin(addr);
+      } catch {
+        proxyAdmin = ProxyAdminDeployer.deployProxyAdmin(fs);
+      }
 
-            bytes memory initData = "";
-            address proxy = TransparentProxyDeployer.deployTransparentProxy(
-                fs,
-                address(proxyAdmin),
-                address(instance),
-                initData,
-                "MintGoldDustMemoir"
-            );
-            console.log("Saved MintGoldDustMemoir filesystem:", proxy);
-            return MintGoldDustMemoir(proxy);
-        }
+      bytes memory initData = "";
+      address proxy = TransparentProxyDeployer.deployTransparentProxy(
+        fs, address(proxyAdmin), address(instance), initData, "MintGoldDustMemoir"
+      );
+      console.log("Saved MintGoldDustMemoir filesystem:", proxy);
+      return MintGoldDustMemoir(proxy);
     }
+  }
 }

--- a/script/foundry/deploy/deploy_MintGoldDustSetPrice.s.sol
+++ b/script/foundry/deploy/deploy_MintGoldDustSetPrice.s.sol
@@ -5,53 +5,54 @@ import {console} from "forge-std/console.sol";
 import {FileSystem} from "../utils/FileSystem.s.sol";
 import {MintGoldDustSetPrice} from "mgd-v2-contracts/marketplace/MintGoldDustSetPrice.sol";
 import {ProxyAdmin, ProxyAdminDeployer} from "./deploy_ProxyAdmin.s.sol";
-import {TransparentUpgradeableProxy, TransparentProxyDeployer} from "./deploy_TransparentProxy.s.sol";
+import {
+  TransparentUpgradeableProxy, TransparentProxyDeployer
+} from "./deploy_TransparentProxy.s.sol";
 
 struct MintGoldDustSetPriceParams {
-    address mintGoldDustCompany;
-    address payable mintGoldDustERC721Address;
-    address payable mintGoldDustERC1155Address;
+  address mintGoldDustCompany;
+  address payable mintGoldDustERC721Address;
+  address payable mintGoldDustERC1155Address;
 }
 
 library MintGoldDustSetPriceDeployer {
-    function deployMintGoldDustSetPrice(
-        FileSystem fs,
-        MintGoldDustSetPriceParams memory initParams,
-        bool onlyImplementation
-    ) internal returns (MintGoldDustSetPrice) {
-        string memory chainName = fs.getChainName(block.chainid);
-        console.log("Deploying MintGoldDustSetPrice...");
+  function deployMintGoldDustSetPrice(
+    FileSystem fs,
+    MintGoldDustSetPriceParams memory initParams,
+    bool onlyImplementation
+  )
+    internal
+    returns (MintGoldDustSetPrice)
+  {
+    string memory chainName = fs.getChainName(block.chainid);
+    console.log("Deploying MintGoldDustSetPrice...");
 
-        MintGoldDustSetPrice instance = new MintGoldDustSetPrice();
+    MintGoldDustSetPrice instance = new MintGoldDustSetPrice();
 
-        console.log("MintGoldDustSetPrice implementation:", address(instance));
+    console.log("MintGoldDustSetPrice implementation:", address(instance));
 
-        if (onlyImplementation) {
-            return instance;
-        } else {
-            ProxyAdmin proxyAdmin;
-            try fs.getAddress("ProxyAdmin", chainName) returns (address addr) {
-                proxyAdmin = ProxyAdmin(addr);
-            } catch {
-                proxyAdmin = ProxyAdminDeployer.deployProxyAdmin(fs);
-            }
+    if (onlyImplementation) {
+      return instance;
+    } else {
+      ProxyAdmin proxyAdmin;
+      try fs.getAddress("ProxyAdmin", chainName) returns (address addr) {
+        proxyAdmin = ProxyAdmin(addr);
+      } catch {
+        proxyAdmin = ProxyAdminDeployer.deployProxyAdmin(fs);
+      }
 
-            bytes memory initData = abi.encodeWithSelector(
-                MintGoldDustSetPrice.initializeChild.selector,
-                initParams.mintGoldDustCompany,
-                initParams.mintGoldDustERC721Address,
-                initParams.mintGoldDustERC1155Address
-            );
+      bytes memory initData = abi.encodeWithSelector(
+        MintGoldDustSetPrice.initializeChild.selector,
+        initParams.mintGoldDustCompany,
+        initParams.mintGoldDustERC721Address,
+        initParams.mintGoldDustERC1155Address
+      );
 
-            address proxy = TransparentProxyDeployer.deployTransparentProxy(
-                fs,
-                address(proxyAdmin),
-                address(instance),
-                initData,
-                "MintGoldDustSetPrice"
-            );
-            console.log("Saved MintGoldDustSetPrice filesystem:", proxy);
-            return MintGoldDustSetPrice(proxy);
-        }
+      address proxy = TransparentProxyDeployer.deployTransparentProxy(
+        fs, address(proxyAdmin), address(instance), initData, "MintGoldDustSetPrice"
+      );
+      console.log("Saved MintGoldDustSetPrice filesystem:", proxy);
+      return MintGoldDustSetPrice(proxy);
     }
+  }
 }

--- a/script/foundry/deploy/deploy_ProxyAdmin.s.sol
+++ b/script/foundry/deploy/deploy_ProxyAdmin.s.sol
@@ -6,15 +6,15 @@ import {FileSystem} from "../utils/FileSystem.s.sol";
 import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 
 library ProxyAdminDeployer {
-    function deployProxyAdmin(FileSystem fs) internal returns (ProxyAdmin) {
-        string memory chainName = fs.getChainName(block.chainid);
+  function deployProxyAdmin(FileSystem fs) internal returns (ProxyAdmin) {
+    string memory chainName = fs.getChainName(block.chainid);
 
-        console.log("Deploying ProxyAdmin...");
-        ProxyAdmin proxyAdmin = new ProxyAdmin();
-        console.log("ProxyAdmin {ProxyAdmin}:", address(proxyAdmin));
+    console.log("Deploying ProxyAdmin...");
+    ProxyAdmin proxyAdmin = new ProxyAdmin();
+    console.log("ProxyAdmin {ProxyAdmin}:", address(proxyAdmin));
 
-        fs.saveAddress("ProxyAdmin", chainName, address(proxyAdmin));
-        console.log("Saved ProxyAdmin:", address(proxyAdmin));
-        return proxyAdmin;
-    }
+    fs.saveAddress("ProxyAdmin", chainName, address(proxyAdmin));
+    console.log("Saved ProxyAdmin:", address(proxyAdmin));
+    return proxyAdmin;
+  }
 }

--- a/script/foundry/deploy/deploy_TransparentProxy.s.sol
+++ b/script/foundry/deploy/deploy_TransparentProxy.s.sol
@@ -4,37 +4,31 @@ pragma solidity 0.8.18;
 import {console} from "forge-std/console.sol";
 import {FileSystem} from "../utils/FileSystem.s.sol";
 import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
-import {TransparentUpgradeableProxy} from "../../../src/utils/openzeppelin/TransparentUpgradeableProxy.sol";
+import {TransparentUpgradeableProxy} from
+  "../../../src/utils/openzeppelin/TransparentUpgradeableProxy.sol";
 
 library TransparentProxyDeployer {
-    function deployTransparentProxy(
-        FileSystem fs,
-        address proxyAdmin,
-        address implementation,
-        bytes memory initData,
-        string memory contractLabel
-    ) internal returns (address) {
-        string memory chainName = fs.getChainName(block.chainid);
+  function deployTransparentProxy(
+    FileSystem fs,
+    address proxyAdmin,
+    address implementation,
+    bytes memory initData,
+    string memory contractLabel
+  )
+    internal
+    returns (address)
+  {
+    string memory chainName = fs.getChainName(block.chainid);
 
-        address proxy;
-        bytes memory contructorArgs = abi.encode(
-            implementation,
-            proxyAdmin,
-            initData
-        );
-        console.log("TransparentUpgradeableProxy constructor arguments:");
-        console.logBytes(contructorArgs);
+    address proxy;
+    bytes memory contructorArgs = abi.encode(implementation, proxyAdmin, initData);
+    console.log("TransparentUpgradeableProxy constructor arguments:");
+    console.logBytes(contructorArgs);
 
-        proxy = address(
-            new TransparentUpgradeableProxy(
-                implementation,
-                proxyAdmin,
-                initData
-            )
-        );
+    proxy = address(new TransparentUpgradeableProxy(implementation, proxyAdmin, initData));
 
-        console.log("TransparentUpgradeableProxy deployed:", proxy);
-        fs.saveAddress(contractLabel, chainName, proxy);
-        return proxy;
-    }
+    console.log("TransparentUpgradeableProxy deployed:", proxy);
+    fs.saveAddress(contractLabel, chainName, proxy);
+    return proxy;
+  }
 }

--- a/script/foundry/tasks/SetValidatorL2Sync.s.sol
+++ b/script/foundry/tasks/SetValidatorL2Sync.s.sol
@@ -7,74 +7,59 @@ import {MintGoldDustCompany} from "mgd-v2-contracts/marketplace/MintGoldDustComp
 import {MgdCompanyL2Sync, CrossAction} from "../../../src/MgdCompanyL2Sync.sol";
 
 contract SetValidatorL2Sync is Script {
-    /// PARAMS TO BE SET
-    MgdCompanyL2Sync public constant MGDL2SYNC =
-        MgdCompanyL2Sync(0x9ec99f79510fe675c22e537B505c4B3D0e487Dbe);
-    uint256 public constant TARGET_CHAIN_ID = 84532;
-    address public constant ADDRESS_TO_SET_VALIDATOR =
-        0x4c56Bb56b27cc3Bb46FA5925dcF34Bf068C4558E;
-    bool public constant NEW_STATE = false;
-    uint256 public constant DEADLINE = 1701417600;
+  /// PARAMS TO BE SET
+  MgdCompanyL2Sync public constant MGDL2SYNC =
+    MgdCompanyL2Sync(0x9ec99f79510fe675c22e537B505c4B3D0e487Dbe);
+  uint256 public constant TARGET_CHAIN_ID = 84532;
+  address public constant ADDRESS_TO_SET_VALIDATOR = 0x4c56Bb56b27cc3Bb46FA5925dcF34Bf068C4558E;
+  bool public constant NEW_STATE = false;
+  uint256 public constant DEADLINE = 1701417600;
 
-    /**
-     * @dev Run using shell command:
-     * $forge script --rpc-url $<RPC_CHAIN> --private-key $<PRIVATE_KEY> \
-     * --slow --broadcast script/foundry/SetValidatorL2Sync.s.sol
-     */
-    function run() public {
-        vm.startBroadcast();
+  /**
+   * @dev Run using shell command:
+   * $forge script --rpc-url $<RPC_CHAIN> --private-key $<PRIVATE_KEY> \
+   * --slow --broadcast script/foundry/SetValidatorL2Sync.s.sol
+   */
+  function run() public {
+    vm.startBroadcast();
 
-        require(address(MGDL2SYNC) != address(0), "Set `MGDL2SYNC`");
-        require(
-            MGDL2SYNC.publicKey() != address(0),
-            "Pubkey() in `MGDL2SYNC` undefined"
-        );
-        require(
-            address(MGDL2SYNC.messenger()) != address(0),
-            "crossDomainMessenger() in `MGDL2SYNC` undefined"
-        );
-        require(TARGET_CHAIN_ID != 0, "Set `TARGET_CHAIN_ID`");
-        require(
-            MGDL2SYNC.crossDomainMGDCompany(TARGET_CHAIN_ID) != address(0),
-            "CrossDomain address undefined"
-        );
-        require(
-            ADDRESS_TO_SET_VALIDATOR != address(0),
-            "Set `ADDRESS_TO_SET_VALIDATOR`"
-        );
-        require(DEADLINE != 0, "Set `DEADLINE`");
+    require(address(MGDL2SYNC) != address(0), "Set `MGDL2SYNC`");
+    require(MGDL2SYNC.publicKey() != address(0), "Pubkey() in `MGDL2SYNC` undefined");
+    require(
+      address(MGDL2SYNC.messenger()) != address(0),
+      "crossDomainMessenger() in `MGDL2SYNC` undefined"
+    );
+    require(TARGET_CHAIN_ID != 0, "Set `TARGET_CHAIN_ID`");
+    require(
+      MGDL2SYNC.crossDomainMGDCompany(TARGET_CHAIN_ID) != address(0),
+      "CrossDomain address undefined"
+    );
+    require(ADDRESS_TO_SET_VALIDATOR != address(0), "Set `ADDRESS_TO_SET_VALIDATOR`");
+    require(DEADLINE != 0, "Set `DEADLINE`");
 
-        bytes32 digest = MGDL2SYNC.getDigestToSign(
-            CrossAction.SetValidator,
-            ADDRESS_TO_SET_VALIDATOR,
-            NEW_STATE,
-            TARGET_CHAIN_ID,
-            DEADLINE
-        );
-        console.log("Digest:");
-        console.logBytes32(digest);
+    bytes32 digest = MGDL2SYNC.getDigestToSign(
+      CrossAction.SetValidator, ADDRESS_TO_SET_VALIDATOR, NEW_STATE, TARGET_CHAIN_ID, DEADLINE
+    );
+    console.log("Digest:");
+    console.logBytes32(digest);
 
-        uint256 privKey = getPrivKey();
-        require(privKey != 0, "Set `MGD_SIGNER_KEY` in `.env` file");
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privKey, digest);
+    uint256 privKey = getPrivKey();
+    require(privKey != 0, "Set `MGD_SIGNER_KEY` in `.env` file");
+    (uint8 v, bytes32 r, bytes32 s) = vm.sign(privKey, digest);
 
-        bytes memory signature = abi.encodePacked(r, s, v);
-        console.log("signature:");
-        console.logBytes(signature);
+    bytes memory signature = abi.encodePacked(r, s, v);
+    console.log("signature:");
+    console.logBytes(signature);
 
-        MGDL2SYNC.setValidatorWithL2Sync(
-            ADDRESS_TO_SET_VALIDATOR,
-            NEW_STATE,
-            TARGET_CHAIN_ID,
-            DEADLINE,
-            signature
-        );
+    MGDL2SYNC.setValidatorWithL2Sync(
+      ADDRESS_TO_SET_VALIDATOR, NEW_STATE, TARGET_CHAIN_ID, DEADLINE, signature
+    );
 
-        vm.stopBroadcast();
-    }
+    vm.stopBroadcast();
+  }
 
-    function getPrivKey() internal view returns (uint256 key) {
-        bytes32 k = vm.envBytes32("MGD_SIGNER_KEY");
-        key = uint256(k);
-    }
+  function getPrivKey() internal view returns (uint256 key) {
+    bytes32 k = vm.envBytes32("MGD_SIGNER_KEY");
+    key = uint256(k);
+  }
 }

--- a/script/foundry/tasks/Upgrader.s.sol
+++ b/script/foundry/tasks/Upgrader.s.sol
@@ -4,25 +4,19 @@ pragma solidity 0.8.18;
 import {console} from "forge-std/console.sol";
 import {FileSystem} from "../utils/FileSystem.s.sol";
 import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
-import {ITransparentUpgradeableProxy} from "../../../src/utils/openzeppelin/TransparentUpgradeableProxy.sol";
+import {ITransparentUpgradeableProxy} from
+  "../../../src/utils/openzeppelin/TransparentUpgradeableProxy.sol";
 
 library Upgrader {
-    function upgrade(
-        FileSystem fs,
-        address proxy,
-        address newImplementation
-    ) internal {
-        string memory chainName = fs.getChainName(block.chainid);
-        ProxyAdmin proxyAdmin;
-        try fs.getAddress("ProxyAdmin", chainName) returns (address addr) {
-            proxyAdmin = ProxyAdmin(addr);
-        } catch {
-            revert("ProxyAdmin not found");
-        }
-        proxyAdmin.upgrade(
-            ITransparentUpgradeableProxy(proxy),
-            newImplementation
-        );
-        console.log("Succesfully upgraded proxy", proxy);
+  function upgrade(FileSystem fs, address proxy, address newImplementation) internal {
+    string memory chainName = fs.getChainName(block.chainid);
+    ProxyAdmin proxyAdmin;
+    try fs.getAddress("ProxyAdmin", chainName) returns (address addr) {
+      proxyAdmin = ProxyAdmin(addr);
+    } catch {
+      revert("ProxyAdmin not found");
     }
+    proxyAdmin.upgrade(ITransparentUpgradeableProxy(proxy), newImplementation);
+    console.log("Succesfully upgraded proxy", proxy);
+  }
 }

--- a/script/foundry/tasks/WhitelistL2Sync.s.sol
+++ b/script/foundry/tasks/WhitelistL2Sync.s.sol
@@ -7,74 +7,59 @@ import {MintGoldDustCompany} from "mgd-v2-contracts/marketplace/MintGoldDustComp
 import {MgdCompanyL2Sync, CrossAction} from "../../../src/MgdCompanyL2Sync.sol";
 
 contract WhitelistL2Sync is Script {
-    /// PARAMS TO BE SET
-    MgdCompanyL2Sync public constant MGDL2SYNC =
-        MgdCompanyL2Sync(0x9ec99f79510fe675c22e537B505c4B3D0e487Dbe);
-    uint256 public constant TARGET_CHAIN_ID = 84532;
-    address public constant ADDRESS_TO_WHITELIST =
-        0x7598940ffE4db0De85cfC2296964c84090854fbe;
-    bool public constant NEW_STATE = false;
-    uint256 public constant DEADLINE = 1701417600;
+  /// PARAMS TO BE SET
+  MgdCompanyL2Sync public constant MGDL2SYNC =
+    MgdCompanyL2Sync(0x9ec99f79510fe675c22e537B505c4B3D0e487Dbe);
+  uint256 public constant TARGET_CHAIN_ID = 84532;
+  address public constant ADDRESS_TO_WHITELIST = 0x7598940ffE4db0De85cfC2296964c84090854fbe;
+  bool public constant NEW_STATE = false;
+  uint256 public constant DEADLINE = 1701417600;
 
-    /**
-     * @dev Run using shell command:
-     * $forge script --rpc-url $<RPC_CHAIN> --private-key $<PRIVATE_KEY> \
-     * --slow --verify --etherscan-api-key $<etherscan_key> --broadcast scripts/WhitelistL2Sync.s.sol
-     */
-    function run() public {
-        vm.startBroadcast();
+  /**
+   * @dev Run using shell command:
+   * $forge script --rpc-url $<RPC_CHAIN> --private-key $<PRIVATE_KEY> \
+   * --slow --verify --etherscan-api-key $<etherscan_key> --broadcast scripts/WhitelistL2Sync.s.sol
+   */
+  function run() public {
+    vm.startBroadcast();
 
-        require(address(MGDL2SYNC) != address(0), "Set `MGDL2SYNC`");
-        require(
-            MGDL2SYNC.publicKey() != address(0),
-            "Pubkey() in `MGDL2SYNC` undefined"
-        );
-        require(
-            address(MGDL2SYNC.messenger()) != address(0),
-            "crossDomainMessenger() in `MGDL2SYNC` undefined"
-        );
-        require(TARGET_CHAIN_ID != 0, "Set `TARGET_CHAIN_ID`");
-        require(
-            MGDL2SYNC.crossDomainMGDCompany(TARGET_CHAIN_ID) != address(0),
-            "CrossDomain address undefined"
-        );
-        require(
-            ADDRESS_TO_WHITELIST != address(0),
-            "Set `ADDRESS_TO_WHITELIST`"
-        );
-        require(DEADLINE != 0, "Set `DEADLINE`");
+    require(address(MGDL2SYNC) != address(0), "Set `MGDL2SYNC`");
+    require(MGDL2SYNC.publicKey() != address(0), "Pubkey() in `MGDL2SYNC` undefined");
+    require(
+      address(MGDL2SYNC.messenger()) != address(0),
+      "crossDomainMessenger() in `MGDL2SYNC` undefined"
+    );
+    require(TARGET_CHAIN_ID != 0, "Set `TARGET_CHAIN_ID`");
+    require(
+      MGDL2SYNC.crossDomainMGDCompany(TARGET_CHAIN_ID) != address(0),
+      "CrossDomain address undefined"
+    );
+    require(ADDRESS_TO_WHITELIST != address(0), "Set `ADDRESS_TO_WHITELIST`");
+    require(DEADLINE != 0, "Set `DEADLINE`");
 
-        bytes32 digest = MGDL2SYNC.getDigestToSign(
-            CrossAction.SetWhitelist,
-            ADDRESS_TO_WHITELIST,
-            NEW_STATE,
-            TARGET_CHAIN_ID,
-            DEADLINE
-        );
-        console.log("Digest:");
-        console.logBytes32(digest);
+    bytes32 digest = MGDL2SYNC.getDigestToSign(
+      CrossAction.SetWhitelist, ADDRESS_TO_WHITELIST, NEW_STATE, TARGET_CHAIN_ID, DEADLINE
+    );
+    console.log("Digest:");
+    console.logBytes32(digest);
 
-        uint256 privKey = getPrivKey();
-        require(privKey != 0, "Set `MGD_SIGNER_KEY` in `.env` file");
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privKey, digest);
+    uint256 privKey = getPrivKey();
+    require(privKey != 0, "Set `MGD_SIGNER_KEY` in `.env` file");
+    (uint8 v, bytes32 r, bytes32 s) = vm.sign(privKey, digest);
 
-        bytes memory signature = abi.encodePacked(r, s, v);
-        console.log("signature:");
-        console.logBytes(signature);
+    bytes memory signature = abi.encodePacked(r, s, v);
+    console.log("signature:");
+    console.logBytes(signature);
 
-        MGDL2SYNC.whitelistWithL2Sync(
-            ADDRESS_TO_WHITELIST,
-            NEW_STATE,
-            TARGET_CHAIN_ID,
-            DEADLINE,
-            signature
-        );
+    MGDL2SYNC.whitelistWithL2Sync(
+      ADDRESS_TO_WHITELIST, NEW_STATE, TARGET_CHAIN_ID, DEADLINE, signature
+    );
 
-        vm.stopBroadcast();
-    }
+    vm.stopBroadcast();
+  }
 
-    function getPrivKey() internal view returns (uint256 key) {
-        bytes32 k = vm.envBytes32("MGD_SIGNER_KEY");
-        key = uint256(k);
-    }
+  function getPrivKey() internal view returns (uint256 key) {
+    bytes32 k = vm.envBytes32("MGD_SIGNER_KEY");
+    key = uint256(k);
+  }
 }

--- a/script/foundry/utils/FileSystem.s.sol
+++ b/script/foundry/utils/FileSystem.s.sol
@@ -6,55 +6,52 @@ import {ScriptConstants} from "./ScriptConstants.s.sol";
 import {console} from "forge-std/console.sol";
 
 contract FileSystem is Script, ScriptConstants {
-    error FileNotFound(string chainName, string contractLabel);
+  error FileNotFound(string chainName, string contractLabel);
 
-    bytes temp;
+  bytes temp;
 
-    function saveAddress(
-        string memory contractLabel,
-        string memory chainName,
-        address addr
-    ) public {
-        string memory path = getContractLabelPathAt(contractLabel, chainName);
-        createAndSaveFile(path, vm.toString(addr));
+  function saveAddress(string memory contractLabel, string memory chainName, address addr) public {
+    string memory path = getContractLabelPathAt(contractLabel, chainName);
+    createAndSaveFile(path, vm.toString(addr));
+  }
+
+  function getAddress(
+    string memory contractLabel,
+    string memory chainName
+  )
+    public
+    returns (address addr)
+  {
+    string memory content = vm.readFile(getContractLabelPathAt(contractLabel, chainName));
+    temp = bytes(content);
+    uint256 contentLength = temp.length;
+    if (contentLength > 42) {
+      uint256 pops = contentLength - 42;
+      for (uint256 i = 0; i < pops; i++) {
+        temp.pop();
+      }
     }
+    string memory modContent = string(temp);
+    addr = vm.parseAddress(modContent);
+    delete temp;
+  }
 
-    function getAddress(
-        string memory contractLabel,
-        string memory chainName
-    ) public returns (address addr) {
-        string memory content = vm.readFile(
-            getContractLabelPathAt(contractLabel, chainName)
-        );
-        temp = bytes(content);
-        uint256 contentLength = temp.length;
-        if (contentLength > 42) {
-            uint256 pops = contentLength - 42;
-            for (uint256 i = 0; i < pops; i++) {
-                temp.pop();
-            }
-        }
-        string memory modContent = string(temp);
-        addr = vm.parseAddress(modContent);
-        delete temp;
-    }
+  function getContractLabelPathAt(
+    string memory contractLabel,
+    string memory chainName
+  )
+    public
+    pure
+    returns (string memory path)
+  {
+    path = string.concat("deployments/", chainName, "/", contractLabel);
+  }
 
-    function getContractLabelPathAt(
-        string memory contractLabel,
-        string memory chainName
-    ) public pure returns (string memory path) {
-        path = string.concat("deployments/", chainName, "/", contractLabel);
+  function createAndSaveFile(string memory path, string memory content) public {
+    try vm.removeFile(path) {}
+    catch {
+      console.log(string(abi.encodePacked("Creating a new record at ", path)));
     }
-
-    function createAndSaveFile(
-        string memory path,
-        string memory content
-    ) public {
-        try vm.removeFile(path) {} catch {
-            console.log(
-                string(abi.encodePacked("Creating a new record at ", path))
-            );
-        }
-        vm.writeLine(path, content);
-    }
+    vm.writeLine(path, content);
+  }
 }

--- a/script/foundry/utils/ScriptConstants.s.sol
+++ b/script/foundry/utils/ScriptConstants.s.sol
@@ -2,47 +2,45 @@
 pragma solidity 0.8.18;
 
 contract ScriptConstants {
-    uint256 internal constant MAINNET_CHAIN_ID = 1;
-    uint256 internal constant SEPOLIA_CHAIN_ID = 11155111;
-    uint256 internal constant BASE_CHAIN_ID = 8453;
-    uint256 internal constant BASE_SEPOLIA_CHAIN_ID = 84532;
-    uint256 internal constant LOCAL = 31337;
+  uint256 internal constant MAINNET_CHAIN_ID = 1;
+  uint256 internal constant SEPOLIA_CHAIN_ID = 11155111;
+  uint256 internal constant BASE_CHAIN_ID = 8453;
+  uint256 internal constant BASE_SEPOLIA_CHAIN_ID = 84532;
+  uint256 internal constant LOCAL = 31337;
 
-    mapping(uint256 => string) internal _chainNames;
-    mapping(uint256 => string) internal _pairChainName;
-    mapping(uint256 => uint256) internal _pairChainId;
+  mapping(uint256 => string) internal _chainNames;
+  mapping(uint256 => string) internal _pairChainName;
+  mapping(uint256 => uint256) internal _pairChainId;
 
-    constructor() {
-        _chainNames[MAINNET_CHAIN_ID] = "mainnet";
-        _chainNames[SEPOLIA_CHAIN_ID] = "sepolia";
-        _chainNames[BASE_CHAIN_ID] = "base";
-        _chainNames[BASE_SEPOLIA_CHAIN_ID] = "base-sepolia";
-        _chainNames[LOCAL] = "local";
+  constructor() {
+    _chainNames[MAINNET_CHAIN_ID] = "mainnet";
+    _chainNames[SEPOLIA_CHAIN_ID] = "sepolia";
+    _chainNames[BASE_CHAIN_ID] = "base";
+    _chainNames[BASE_SEPOLIA_CHAIN_ID] = "base-sepolia";
+    _chainNames[LOCAL] = "local";
 
-        _pairChainName[MAINNET_CHAIN_ID] = "base";
-        _pairChainName[SEPOLIA_CHAIN_ID] = "base-sepolia";
-        _pairChainName[BASE_CHAIN_ID] = "mainnet";
-        _pairChainName[BASE_SEPOLIA_CHAIN_ID] = "sepolia";
-        _pairChainName[LOCAL] = "local";
+    _pairChainName[MAINNET_CHAIN_ID] = "base";
+    _pairChainName[SEPOLIA_CHAIN_ID] = "base-sepolia";
+    _pairChainName[BASE_CHAIN_ID] = "mainnet";
+    _pairChainName[BASE_SEPOLIA_CHAIN_ID] = "sepolia";
+    _pairChainName[LOCAL] = "local";
 
-        _pairChainId[MAINNET_CHAIN_ID] = BASE_CHAIN_ID;
-        _pairChainId[SEPOLIA_CHAIN_ID] = BASE_SEPOLIA_CHAIN_ID;
-        _pairChainId[BASE_CHAIN_ID] = MAINNET_CHAIN_ID;
-        _pairChainId[BASE_SEPOLIA_CHAIN_ID] = SEPOLIA_CHAIN_ID;
-        _pairChainId[LOCAL] = LOCAL;
-    }
+    _pairChainId[MAINNET_CHAIN_ID] = BASE_CHAIN_ID;
+    _pairChainId[SEPOLIA_CHAIN_ID] = BASE_SEPOLIA_CHAIN_ID;
+    _pairChainId[BASE_CHAIN_ID] = MAINNET_CHAIN_ID;
+    _pairChainId[BASE_SEPOLIA_CHAIN_ID] = SEPOLIA_CHAIN_ID;
+    _pairChainId[LOCAL] = LOCAL;
+  }
 
-    function getChainName(uint256 chainId) public view returns (string memory) {
-        return _chainNames[chainId];
-    }
+  function getChainName(uint256 chainId) public view returns (string memory) {
+    return _chainNames[chainId];
+  }
 
-    function getPairChainName(
-        uint256 chainId
-    ) public view returns (string memory) {
-        return _pairChainName[chainId];
-    }
+  function getPairChainName(uint256 chainId) public view returns (string memory) {
+    return _pairChainName[chainId];
+  }
 
-    function getPairChainId(uint256 chainId) public view returns (uint256) {
-        return _pairChainId[chainId];
-    }
+  function getPairChainId(uint256 chainId) public view returns (uint256) {
+    return _pairChainId[chainId];
+  }
 }

--- a/src/MgdL2NFTEscrow.sol
+++ b/src/MgdL2NFTEscrow.sol
@@ -321,7 +321,7 @@ contract MgdL2NFTEscrow is Initializable, IERC721Receiver, IERC1155Receiver {
     view
     returns (uint256 voucherId, bytes32 blockHash)
   {
-    blockHash = blockhash(block.number);
+    blockHash = blockhash(block.number - 1);
     voucherId = uint256(keccak256(abi.encode(nft, tokenId, amount, owner, blockHash, marketData)));
   }
 

--- a/src/voucher/MgdL2BaseVoucher.sol
+++ b/src/voucher/MgdL2BaseVoucher.sol
@@ -271,7 +271,7 @@ abstract contract MgdL2BaseVoucher is MgdL2BaseNFT {
     view
     returns (uint256 identifier)
   {
-    identifier = uint256(keccak256(abi.encode(blockhash(block.number), tokenData)));
+    identifier = uint256(keccak256(abi.encode(blockhash(block.number - 1), tokenData)));
   }
 
   function _generateL1RedeemKey(
@@ -286,7 +286,7 @@ abstract contract MgdL2BaseVoucher is MgdL2BaseNFT {
     view
     returns (uint256 key, bytes32 blockHash)
   {
-    blockHash = blockhash(block.number);
+    blockHash = blockhash(block.number - 1);
     if (tokenId == _REF_NUMBER) {
       bytes32 hashedUriMemoir =
         keccak256(abi.encode(_tokenURIs[voucherId], _tokenIdMemoir[voucherId]));

--- a/test/foundry/VoucherTests.t.sol
+++ b/test/foundry/VoucherTests.t.sol
@@ -136,12 +136,24 @@ contract VoucherTests is CommonSigners, BaseL2Constants, MgdTestConstants {
     vm.prank(Bob.addr);
     uint256 vId = l2voucher721.mintNft(_TOKEN_URI, _ROYALTY_PERCENT, 1, bytes(_MEMOIR));
     assertEq(l2voucher721.ownerOf(vId), Bob.addr);
+
+    vm.roll(block.number + 1);
+
+    vm.prank(Bob.addr);
+    uint256 vId2 = l2voucher721.mintNft(_TOKEN_URI, _ROYALTY_PERCENT, 1, bytes(_MEMOIR));
+    assertEq(l2voucher721.ownerOf(vId2), Bob.addr);
   }
 
   function test_mintingNativeVoucherThatRepresents1155() public {
     vm.prank(Bob.addr);
     uint256 vId = l2voucher1155.mintNft(_TOKEN_URI, _ROYALTY_PERCENT, _EDITIONS, bytes(_MEMOIR));
     assertEq(l2voucher1155.balanceOf(Bob.addr, vId), _EDITIONS);
+
+    vm.roll(block.number + 1);
+
+    vm.prank(Bob.addr);
+    uint256 vId2 = l2voucher1155.mintNft(_TOKEN_URI, _ROYALTY_PERCENT, _EDITIONS, bytes(_MEMOIR));
+    assertEq(l2voucher1155.balanceOf(Bob.addr, vId2), _EDITIONS);
   }
 
   function test_mintingNativeSplitMinted721Voucher() public {

--- a/test/foundry/utils/Helpers.t.sol
+++ b/test/foundry/utils/Helpers.t.sol
@@ -42,7 +42,7 @@ contract Helpers is Test {
     view
     returns (uint256 voucherId, bytes32 blockHash)
   {
-    blockHash = blockhash(block.number);
+    blockHash = blockhash(block.number - 1);
     voucherId = uint256(keccak256(abi.encode(nft, tokenId, amount, owner, blockHash, marketData)));
   }
 
@@ -68,7 +68,7 @@ contract Helpers is Test {
     view
     returns (uint256 key, bytes32 blockHash)
   {
-    blockHash = blockhash(block.number);
+    blockHash = blockhash(block.number - 1);
     if (tokenId == _REF_NUMBER) {
       bytes32 hashedUriMemoir = keccak256(abi.encode(tokenURI, tokenIdMemoir));
       key = uint256(


### PR DESCRIPTION
In the codebase, the operation call: `blockhash(block.number)` , where `block.number ` is the ongoing block where the tx will be included, always returns `zero`. Using the previous call as an ingredient to compute a random Id results useless because as already explained it consistently returns zero. 

This PR proposes the following solution :
- use `blockhash(block.number - 1)`  instead. 

The hash of the previous known block is known and it will not be zero making it usefull to generate pseudo-random ids.