### PR TITLE
Fix:  missing method on voucher for split payments

### DIFF
--- a/src/voucher/MgdL2BaseNFT.sol
+++ b/src/voucher/MgdL2BaseNFT.sol
@@ -42,7 +42,6 @@ abstract contract MgdL2BaseNFT is Initializable, PausableUpgradeable, Reentrancy
   error MgdL2Voucher__notAuthorized(string restriction);
   error MgdL2Voucher__checkRoyalty_moreThanMax();
   error MgdL2Voucher__splitMint_invalidArray();
-  error MgdL2Voucher__collectorMint_disabledInL2();
 
   MgdCompanyL2Sync internal _mgdCompany;
   address internal _mintGoldDustSetPrice;
@@ -147,6 +146,10 @@ abstract contract MgdL2BaseNFT is Initializable, PausableUpgradeable, Reentrancy
     return _voucherMarketData[id].royaltyPercent;
   }
 
+  function tokenIdCollaboratorsQuantity(uint256 id) external view returns (uint256) {
+    return uint256(_voucherMarketData[id].collabsQuantity);
+  }
+
   function getVoucherMarketData(uint256 id) public view returns (MgdL1MarketData memory) {
     return _voucherMarketData[id];
   }
@@ -196,46 +199,6 @@ abstract contract MgdL2BaseNFT is Initializable, PausableUpgradeable, Reentrancy
     public
     virtual
     returns (uint256);
-
-  /// @notice Collector mint is disabled in MGD L2 contracts.
-  /// @dev  Kept this function to throw error message when called
-  /// by other MGD v2-core unchanged contracts.
-  function collectorMint(
-    string memory,
-    uint256,
-    uint256,
-    address,
-    bytes memory,
-    uint256,
-    address
-  )
-    external
-    pure
-    returns (uint256)
-  {
-    revert MgdL2Voucher__collectorMint_disabledInL2();
-  }
-
-  /// @notice Collector split mint is disabled in MGD L2 contracts.
-  /// @dev  Kept this function to throw error message when called
-  /// by other MGD v2-core unchanged contracts.
-  function collectorSplitMint(
-    string memory,
-    uint256,
-    address[] memory,
-    uint256[] memory,
-    uint256,
-    address,
-    bytes memory,
-    uint256,
-    address
-  )
-    external
-    pure
-    returns (uint256)
-  {
-    revert MgdL2Voucher__collectorMint_disabledInL2();
-  }
 
   /// @notice Reduces the quantity of remaining items available for primary sale for a specific token.
   ///         Only executes the update if there is a non-zero quantity of the token remaining for primary sale.

--- a/src/voucher/MgdL2BaseNFT.sol
+++ b/src/voucher/MgdL2BaseNFT.sol
@@ -142,7 +142,7 @@ abstract contract MgdL2BaseNFT is Initializable, PausableUpgradeable, Reentrancy
    * @notice Getter required by the MGD Marketplace contracts.
    * @param id the id of the voucher
    */
-  function tokenIdRoyaltyPercentage(uint256 id) external view returns (uint256) {
+  function tokenIdRoyaltyPercent(uint256 id) external view returns (uint256) {
     return _voucherMarketData[id].royaltyPercent;
   }
 

--- a/test/foundry/VoucherTests.t.sol
+++ b/test/foundry/VoucherTests.t.sol
@@ -189,43 +189,4 @@ contract VoucherTests is CommonSigners, BaseL2Constants, MgdTestConstants {
     );
     assertEq(l2voucher1155.balanceOf(Bob.addr, vId), _EDITIONS);
   }
-
-  function test_collectorMintingMethodsReverts() public {
-    // l2voucher.collectorMint
-    vm.prank(Bob.addr);
-    vm.expectRevert(MgdL2BaseNFT.MgdL2Voucher__collectorMint_disabledInL2.selector);
-    l2voucher721.collectorMint(
-      _TOKEN_URI, _ROYALTY_PERCENT, 1, Bob.addr, bytes(_MEMOIR), 1234, address(this)
-    );
-
-    vm.prank(Bob.addr);
-    vm.expectRevert(MgdL2BaseNFT.MgdL2Voucher__collectorMint_disabledInL2.selector);
-    l2voucher1155.collectorMint(
-      _TOKEN_URI, _ROYALTY_PERCENT, 1, Bob.addr, bytes(_MEMOIR), 1234, address(this)
-    );
-
-    // l2voucher.collectorSplitMint
-    address[] memory collabs = new address[](2);
-    collabs[0] = Charlie.addr;
-    collabs[1] = David.addr;
-
-    uint256[] memory collabsPercent = new uint256[](3);
-    collabsPercent[0] = 35e18;
-    collabsPercent[1] = 20e18;
-    collabsPercent[2] = 45e18;
-
-    vm.prank(Bob.addr);
-    vm.expectRevert(MgdL2BaseNFT.MgdL2Voucher__collectorMint_disabledInL2.selector);
-    l2voucher1155.collectorSplitMint(
-      _TOKEN_URI,
-      _ROYALTY_PERCENT,
-      collabs,
-      collabsPercent,
-      1,
-      Bob.addr,
-      bytes(_MEMOIR),
-      1234,
-      address(this)
-    );
-  }
 }


### PR DESCRIPTION
This PR adds the following missing method on the MgdL2BaseNFT.sol contract:

```
function tokenIdCollaboratorsQuantity(uint256 id) external view returns (uint256)
```

In addition, to reduce contract size, the collectorMint methods are removed in L2.